### PR TITLE
Refactor useMessages hook, re-export items from the JS SDK, and update docs

### DIFF
--- a/examples/react-quickstart/src/components/Conversations.tsx
+++ b/examples/react-quickstart/src/components/Conversations.tsx
@@ -3,7 +3,7 @@ import {
   useConversations,
   useStreamConversations,
 } from "@xmtp/react-sdk";
-import type { Conversation } from "@xmtp/xmtp-js";
+import type { Conversation } from "@xmtp/react-sdk";
 import { ChatBubbleLeftIcon } from "@heroicons/react/24/outline";
 import { useCallback, useState } from "react";
 import { Notification } from "./Notification";

--- a/examples/react-quickstart/src/components/Inbox.tsx
+++ b/examples/react-quickstart/src/components/Inbox.tsx
@@ -1,6 +1,6 @@
 import "./Inbox.css";
 import { useCallback, useState } from "react";
-import type { Conversation } from "@xmtp/xmtp-js";
+import type { Conversation } from "@xmtp/react-sdk";
 import {
   ArrowRightOnRectangleIcon,
   PlusCircleIcon,

--- a/examples/react-quickstart/src/components/Messages.tsx
+++ b/examples/react-quickstart/src/components/Messages.tsx
@@ -6,7 +6,7 @@ import {
   useSendMessage,
   useStreamMessages,
 } from "@xmtp/react-sdk";
-import type { Conversation, DecodedMessage } from "@xmtp/xmtp-js";
+import type { Conversation, DecodedMessage } from "@xmtp/react-sdk";
 import { useCallback, useEffect, useRef, useState } from "react";
 import "./Messages.css";
 

--- a/examples/react-quickstart/src/components/NewMessage.tsx
+++ b/examples/react-quickstart/src/components/NewMessage.tsx
@@ -6,7 +6,7 @@ import {
   useCanMessage,
   useStartConversation,
 } from "@xmtp/react-sdk";
-import type { Conversation } from "@xmtp/xmtp-js";
+import type { Conversation } from "@xmtp/react-sdk";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 type NewMessageProps = {

--- a/examples/react-quickstart/src/contexts/WalletContext.tsx
+++ b/examples/react-quickstart/src/contexts/WalletContext.tsx
@@ -1,5 +1,5 @@
 import "@rainbow-me/rainbowkit/styles.css";
-import type { Signer } from "@xmtp/xmtp-js";
+import type { Signer } from "@xmtp/react-sdk";
 import { createContext, useMemo } from "react";
 import { useAccount, useConnect, useDisconnect, useSigner } from "wagmi";
 

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -118,8 +118,8 @@ To learn more about this process, see [Create a client](https://github.com/xmtp/
 **Type**
 
 ```ts
-import { Client } from "@xmtp/xmtp-js";
-import type { ClientOptions, Signer } from "@xmtp/xmtp-js";
+import { Client } from "@xmtp/react-sdk";
+import type { ClientOptions, Signer } from "@xmtp/react-sdk";
 
 const useClient: ({
   options,
@@ -179,9 +179,8 @@ To learn more, see [Manually handle private key storage](https://github.com/xmtp
 **Example**
 
 ```tsx
-import { Client } from "@xmtp/xmtp-js";
-import type { Signer } from "@xmtp/xmtp-js";
-import { useClient } from "@xmtp/react-sdk";
+import { Client, useClient } from "@xmtp/react-sdk";
+import type { Signer } from "@xmtp/react-sdk";
 
 export const CreateClientWithKeys: React.FC<{ signer: Signer }> = ({ signer }) => {
   const { initialize } = useClient({ signer });
@@ -210,7 +209,7 @@ The `useConversations` hook fetches all conversations with the current wallet on
 **Type**
 
 ```ts
-import type { Conversation } from "@xmtp/xmtp-js";
+import type { Conversation } from "@xmtp/react-sdk";
 
 const useConversations: () => {
   conversations: Conversation[];
@@ -247,7 +246,7 @@ The `useStreamConversations` hook listens for new conversations in real-time and
 **Type**
 
 ```ts
-import type { Conversation } from "@xmtp/xmtp-js";
+import type { Conversation } from "@xmtp/react-sdk";
 
 const useStreamConversations: (
   onConversation: (conversation: Conversation) => void,
@@ -261,7 +260,7 @@ const useStreamConversations: (
 ```tsx
 import { useCallback, useState } from "react";
 import { useStreamConversations } from "@xmtp/react-sdk";
-import type { Conversation } from "@xmtp/xmtp-js";
+import type { Conversation } from "@xmtp/react-sdk";
 
 export const NewConversations: React.FC = () => {
   // track streamed conversations
@@ -298,7 +297,7 @@ The `useStartConversation` hook starts a new conversation and sends an initial m
 
 ```ts
 import type { InvitationContext } from "@xmtp/xmtp-js/dist/types/src/Invitation";
-import type { Conversation, SendOptions } from "@xmtp/xmtp-js";
+import type { Conversation, SendOptions } from "@xmtp/react-sdk";
 
 const useStartConversation: <T = string>(
   options?: InvitationContext,
@@ -356,7 +355,7 @@ The `useSendMessage` hook sends a new message into a conversation.
 **Type**
 
 ```ts
-import type { Conversation, SendOptions } from "@xmtp/xmtp-js";
+import type { Conversation, SendOptions } from "@xmtp/react-sdk";
 
 const useSendMessage: <T = string>(
   conversation: Conversation,
@@ -368,7 +367,7 @@ const useSendMessage: <T = string>(
 
 ```tsx
 import { MessageInput, useSendMessage } from "@xmtp/react-sdk";
-import type { Conversation } from "@xmtp/xmtp-js";
+import type { Conversation } from "@xmtp/react-sdk";
 import { useCallback, useState } from "react";
 
 export const SendMessage: React.FC<{ conversation: Conversation }> = ({
@@ -403,7 +402,7 @@ import type {
   Conversation,
   DecodedMessage,
   ListMessagesOptions,
-} from "@xmtp/xmtp-js";
+} from "@xmtp/react-sdk";
 
 const useMessages: (
   conversation?: Conversation,
@@ -420,7 +419,7 @@ const useMessages: (
 
 ```tsx
 import { ConversationMessages, useMessages } from "@xmtp/react-sdk";
-import type { Conversation, DecodedMessage } from "@xmtp/xmtp-js";
+import type { Conversation, DecodedMessage } from "@xmtp/react-sdk";
 
 export const Messages: React.FC<{
   conversation: Conversation;
@@ -452,7 +451,7 @@ The `useStreamMessages` hook streams new conversation messages on mount and expo
 **Type**
 
 ```ts
-import type { Conversation, DecodedMessage } from "@xmtp/xmtp-js";
+import type { Conversation, DecodedMessage } from "@xmtp/react-sdk";
 
 const useStreamMessages: (
   conversation: Conversation,
@@ -466,7 +465,7 @@ const useStreamMessages: (
 
 ```tsx
 import { useStreamMessages } from "@xmtp/react-sdk";
-import type { Conversation, DecodedMessage } from "@xmtp/xmtp-js";
+import type { Conversation, DecodedMessage } from "@xmtp/react-sdk";
 import { useCallback, useEffect, useState } from "react";
 
 export const StreamMessages: React.FC<{
@@ -508,7 +507,7 @@ The `useStreamAllMessages` hook streams new messages from all conversations on m
 **Type**
 
 ```ts
-import type { DecodedMessage } from "@xmtp/xmtp-js";
+import type { DecodedMessage } from "@xmtp/react-sdk";
 
 const useStreamAllMessages: (onMessage: (message: DecodedMessage) => void) => {
   error: unknown;
@@ -519,7 +518,7 @@ const useStreamAllMessages: (onMessage: (message: DecodedMessage) => void) => {
 
 ```tsx
 import { useStreamAllMessages } from "@xmtp/react-sdk";
-import type { DecodedMessage } from "@xmtp/xmtp-js";
+import type { DecodedMessage } from "@xmtp/react-sdk";
 import { useCallback, useState } from "react";
 
 export const StreamAllMessages: React.FC = () => {
@@ -574,6 +573,8 @@ const useCanMessage: () => {
 **Example**
 
 ```tsx
+import { useCanMessage } from "@xmtp/react-sdk";
+
 export const CanMessage: React.FC = () => {
   const [peerAddress, setPeerAddress] = useState("");
   const [isOnNetwork, setIsOnNetwork] = useState(false);

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -457,7 +457,7 @@ export const Messages: React.FC<{
 };
 ```
 
-#### Paging through messages
+#### Page through messages
 
 If a conversation has a lot of messages, it's more performant to page through them rather than fetching them all at once. This can be accomplished by using the `limit` option to limit the number of messages to fetch at a time.
 

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xmtp/react-sdk",
   "description": "XMTP client SDK for React apps written in TypeScript",
-  "version": "1.0.0-preview.20",
+  "version": "1.0.0-preview.26",
   "license": "MIT",
   "type": "module",
   "main": "lib/index.cjs",

--- a/packages/react-sdk/src/helpers/adjustDate.ts
+++ b/packages/react-sdk/src/helpers/adjustDate.ts
@@ -1,0 +1,5 @@
+export const adjustDate = (date: Date, change: number) => {
+  const newDate = new Date(date);
+  newDate.setMilliseconds(date.getMilliseconds() + change);
+  return newDate;
+};

--- a/packages/react-sdk/src/hooks/useMessages.ts
+++ b/packages/react-sdk/src/hooks/useMessages.ts
@@ -3,7 +3,19 @@ import type {
   DecodedMessage,
   ListMessagesOptions,
 } from "@xmtp/xmtp-js";
-import { useEffect, useState } from "react";
+import { SortDirection } from "@xmtp/xmtp-js";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { adjustDate } from "../helpers/adjustDate";
+
+export type UseMessagesOptions = ListMessagesOptions & {
+  /**
+   * Callback function to execute when new messages are fetched
+   */
+  onMessages?: (
+    messages: DecodedMessage[],
+    options: ListMessagesOptions,
+  ) => void;
+};
 
 /**
  * This hook fetches a list of all messages within a conversation on mount. It
@@ -12,28 +24,87 @@ import { useEffect, useState } from "react";
  */
 export const useMessages = (
   conversation?: Conversation,
-  options?: ListMessagesOptions,
+  options?: UseMessagesOptions,
 ) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<unknown | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [messages, setMessages] = useState<DecodedMessage[]>([]);
+  // internal references to start/end times for paging results
+  const startTimeRef = useRef<Date | undefined>(options?.startTime);
+  const endTimeRef = useRef<Date | undefined>(options?.endTime);
 
-  // attempt to fetch conversation messages on mount
+  // // reset start/end time refs when the options change
+  useEffect(() => {
+    startTimeRef.current = options?.startTime;
+    endTimeRef.current = options?.endTime;
+  }, [options]);
+
+  // reset messages when the conversation changes
+  useEffect(() => {
+    setMessages([]);
+  }, [conversation]);
+
+  // fetch the next set of messages based on passed options
+  const next = useCallback(async () => {
+    // limit is required for paging
+    if (conversation && options?.limit && hasMore && messages.length > 0) {
+      const { onMessages, direction, ...otherOptions } = options;
+
+      const lastMessageSentAt = messages[messages.length - 1].sent;
+
+      // update start/end times based on sort direction
+      switch (direction) {
+        case SortDirection.SORT_DIRECTION_UNSPECIFIED:
+        case SortDirection.SORT_DIRECTION_ASCENDING:
+          startTimeRef.current = adjustDate(lastMessageSentAt, 1);
+          break;
+        case SortDirection.SORT_DIRECTION_DESCENDING:
+          endTimeRef.current = adjustDate(lastMessageSentAt, -1);
+          break;
+        // no default
+      }
+
+      // fetch next batch of messages
+      setIsLoading(true);
+      try {
+        const nextMessages = await conversation.messages({
+          ...otherOptions,
+          direction,
+          endTime: endTimeRef.current,
+          startTime: startTimeRef.current,
+        });
+        onMessages?.(nextMessages, otherOptions);
+        setMessages(nextMessages);
+        setHasMore(
+          nextMessages.length > 0 && nextMessages.length === options.limit,
+        );
+        return nextMessages;
+      } catch (e) {
+        setError(e);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    return [];
+  }, [conversation, hasMore, messages, options]);
+
+  // fetch conversation messages on mount
   useEffect(() => {
     const getMessages = async () => {
-      // we must have a conversation first
+      // conversation is required
       if (!conversation) {
         return;
       }
-
       setIsLoading(true);
-
       try {
         const newMessages = await conversation.messages(options);
         setMessages(newMessages);
-        if (newMessages.length > 0) {
-          setHasMore(newMessages.length < (options?.limit ?? 0));
+        options?.onMessages?.(newMessages, options);
+        if (options?.limit) {
+          setHasMore(
+            newMessages.length > 0 && newMessages.length === options.limit,
+          );
         }
       } catch (e) {
         setError(e);
@@ -41,14 +112,14 @@ export const useMessages = (
         setIsLoading(false);
       }
     };
-
     void getMessages();
   }, [conversation, options]);
 
   return {
     error,
+    hasMore,
     isLoading,
     messages,
-    hasMore,
+    next,
   };
 };

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -36,5 +36,7 @@ export { useStreamAllMessages } from "./hooks/useStreamAllMessages";
 export { useStreamConversations } from "./hooks/useStreamConversations";
 export { useStreamMessages } from "./hooks/useStreamMessages";
 
+export { Client, SortDirection } from "@xmtp/xmtp-js";
+
 // re-export types from the JS SDK
 export type * from "@xmtp/xmtp-js";


### PR DESCRIPTION
This PR refactors the `useMessages` hook to allow for easier paging of messages. It also re-exports types, `Client`, and `SortDirection` from `@xmtp/xmtp-js`.

The README has been updated to account for these changes.