### PR TITLE
Add `useCachedMessages` hook, update `useMessages`

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xmtp/react-sdk",
   "description": "XMTP client SDK for React apps written in TypeScript",
-  "version": "1.0.0-preview.29",
+  "version": "1.0.0-preview.31",
   "license": "MIT",
   "type": "module",
   "main": "lib/index.cjs",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -73,7 +73,9 @@
   "dependencies": {
     "@xmtp/xmtp-js": "^9.0.1",
     "date-fns": "^2.30.0",
-    "react": "^18.2.0"
+    "dexie": "^3.2.3",
+    "react": "^18.2.0",
+    "react-18-blockies": "^1.0.6"
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -74,8 +74,7 @@
     "@xmtp/xmtp-js": "^9.0.1",
     "date-fns": "^2.30.0",
     "dexie": "^3.2.3",
-    "react": "^18.2.0",
-    "react-18-blockies": "^1.0.6"
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",

--- a/packages/react-sdk/src/helpers/getConversationId.ts
+++ b/packages/react-sdk/src/helpers/getConversationId.ts
@@ -1,0 +1,14 @@
+import type { Conversation } from "@xmtp/xmtp-js";
+
+/**
+ * Create a unique conversation ID based on sender/receiver addresses and
+ * context values
+ */
+export const getConversationId = (conversation?: Conversation): string =>
+  [
+    conversation?.clientAddress,
+    conversation?.peerAddress,
+    conversation?.context?.conversationId,
+  ]
+    .filter((v) => Boolean(v))
+    .join("/");

--- a/packages/react-sdk/src/helpers/messageDb.ts
+++ b/packages/react-sdk/src/helpers/messageDb.ts
@@ -1,0 +1,38 @@
+import type { DecodedMessage } from "@xmtp/xmtp-js";
+import type { Table } from "dexie";
+import Dexie from "dexie";
+import { getConversationId } from "./getConversationId";
+
+export type CachedMessage = {
+  id: string;
+  cId: string;
+  bytes: Uint8Array;
+  sent: Date;
+};
+
+export class MessagesDB extends Dexie {
+  messages!: Table<CachedMessage>;
+
+  constructor() {
+    super("__XMTP__");
+    this.version(1).stores({
+      messages: "id, cId, sent",
+    });
+  }
+
+  // persist encrypted message to cache
+  async persistMessage(message: DecodedMessage) {
+    const { id, sent } = message;
+    await this.messages.put(
+      {
+        id,
+        cId: getConversationId(message.conversation),
+        bytes: message.toBytes(),
+        sent,
+      },
+      [id, sent],
+    );
+  }
+}
+
+export const messagesDb = new MessagesDB();

--- a/packages/react-sdk/src/helpers/messagesDb.ts
+++ b/packages/react-sdk/src/helpers/messagesDb.ts
@@ -7,6 +7,8 @@ export type CachedMessage = {
   id: string;
   cId: string;
   bytes: Uint8Array;
+  recipientAddress?: string;
+  senderAddress: string;
   sent: Date;
 };
 
@@ -16,19 +18,20 @@ export class MessagesDB extends Dexie {
   constructor() {
     super("__XMTP__");
     this.version(1).stores({
-      messages: "id, cId, sent",
+      messages: "id, [cId+sent]",
     });
   }
 
-  // persist encrypted message to cache
+  // persist message to cache
   async persistMessage(message: DecodedMessage) {
-    const { id, sent } = message;
+    const { id, sent, recipientAddress, senderAddress } = message;
     await this.messages.put(
       {
         id,
         cId: getConversationId(message.conversation),
-        // encrypted message
         bytes: message.toBytes(),
+        recipientAddress,
+        senderAddress,
         sent,
       },
       [id, sent],

--- a/packages/react-sdk/src/helpers/messagesDb.ts
+++ b/packages/react-sdk/src/helpers/messagesDb.ts
@@ -27,6 +27,7 @@ export class MessagesDB extends Dexie {
       {
         id,
         cId: getConversationId(message.conversation),
+        // encrypted message
         bytes: message.toBytes(),
         sent,
       },

--- a/packages/react-sdk/src/helpers/updateLastEntry.ts
+++ b/packages/react-sdk/src/helpers/updateLastEntry.ts
@@ -1,0 +1,33 @@
+import { SortDirection, type DecodedMessage } from "@xmtp/xmtp-js";
+import { adjustDate } from "./adjustDate";
+
+export type UpdateLastEntryOptions = {
+  direction?: string;
+  endTimeRef: React.MutableRefObject<Date | undefined>;
+  startTimeRef: React.MutableRefObject<Date | undefined>;
+  lastEntry?: DecodedMessage;
+  lastEntryRef: React.MutableRefObject<DecodedMessage | undefined>;
+};
+
+/**
+ * Update passed references for paging through messages
+ */
+export const updateLastEntry = ({
+  direction,
+  endTimeRef,
+  startTimeRef,
+  lastEntry,
+  lastEntryRef,
+}: UpdateLastEntryOptions) => {
+  if (lastEntry) {
+    // eslint-disable-next-line no-param-reassign
+    lastEntryRef.current = lastEntry;
+    if (direction === SortDirection.SORT_DIRECTION_DESCENDING) {
+      // eslint-disable-next-line no-param-reassign
+      endTimeRef.current = adjustDate(lastEntry.sent, -1);
+    } else {
+      // eslint-disable-next-line no-param-reassign
+      startTimeRef.current = adjustDate(lastEntry.sent, 1);
+    }
+  }
+};

--- a/packages/react-sdk/src/hooks/useCachedMessages.ts
+++ b/packages/react-sdk/src/hooks/useCachedMessages.ts
@@ -1,0 +1,239 @@
+import type { Client, Conversation, ListMessagesOptions } from "@xmtp/xmtp-js";
+import { DecodedMessage, SortDirection } from "@xmtp/xmtp-js";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Collection, IndexableType } from "dexie";
+import type { CachedMessage } from "../helpers/messageDb";
+import { messagesDb } from "../helpers/messageDb";
+import { getConversationId } from "../helpers/getConversationId";
+import { useClient } from "./useClient";
+import { updateLastEntry } from "../helpers/updateLastEntry";
+
+const filterByConversation = (cId: string) => (cachedMessage: CachedMessage) =>
+  cachedMessage.cId === cId;
+
+const fastForward = (lastEntry: DecodedMessage | undefined, cId: string) => {
+  let fastForwardComplete = false;
+  return (item: CachedMessage) => {
+    if (fastForwardComplete) {
+      return item.cId === cId;
+    }
+    if (lastEntry !== undefined && item.id === lastEntry.id) {
+      fastForwardComplete = true;
+    }
+    return false;
+  };
+};
+
+type GetCachedMessagesOptions = {
+  cId: string;
+  client: Client;
+  direction?: string;
+  initial?: boolean;
+  lastEntry?: DecodedMessage;
+  limit?: number;
+};
+
+const getCachedMessages = async ({
+  cId,
+  client,
+  direction,
+  initial,
+  lastEntry,
+  limit,
+}: GetCachedMessagesOptions) => {
+  let messagesQuery: Collection<CachedMessage, IndexableType>;
+
+  if (initial) {
+    messagesQuery = messagesDb.messages
+      .orderBy("sent")
+      .filter(filterByConversation(cId));
+  } else {
+    messagesQuery = messagesDb.messages
+      .where("sent")
+      .aboveOrEqual(lastEntry?.sent)
+      .filter(fastForward(lastEntry, cId));
+  }
+
+  // apply limit
+  if (limit) {
+    messagesQuery = messagesQuery.limit(limit);
+  }
+
+  // apply sorting
+  if (direction === SortDirection.SORT_DIRECTION_DESCENDING) {
+    messagesQuery = messagesQuery.reverse();
+  }
+
+  const cachedMessages = await messagesQuery.toArray();
+
+  // decode cached messages
+  return Promise.all(
+    cachedMessages.map(async (m) => DecodedMessage.fromBytes(m.bytes, client)),
+  );
+};
+
+export type UseCachedMessagesOptions = ListMessagesOptions & {
+  /**
+   * Callback function to execute when new messages are fetched
+   */
+  onMessages?: (
+    messages: DecodedMessage[],
+    options: ListMessagesOptions,
+  ) => void;
+  /**
+   * Callback function to execute when an error occurs
+   */
+  onError?: (error: unknown) => void;
+};
+
+/**
+ * This hook fetches a list of all messages within a conversation on mount,
+ * backed by a cache stored in IndexedDB. Like the `useMessages` hook, it also
+ * exposes loading and error states and whether or not there are more messages
+ * based on the options passed.
+ */
+export const useCachedMessages = (
+  conversation?: Conversation,
+  options?: UseCachedMessagesOptions,
+) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<unknown | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [messages, setMessages] = useState<DecodedMessage[]>([]);
+  const { client } = useClient();
+  // internal references to start/end times for paging results
+  const startTimeRef = useRef<Date | undefined>(options?.startTime);
+  const endTimeRef = useRef<Date | undefined>(options?.endTime);
+  // internal reference to the last entry in the cache
+  const lastCacheEntryRef = useRef<DecodedMessage | undefined>();
+
+  // destructure options for more granular dependency arrays
+  const {
+    checkAddresses,
+    direction,
+    limit,
+    onError,
+    onMessages,
+    startTime,
+    endTime,
+  } = options ?? {};
+
+  // reset start/end time refs when the options or conversation change
+  useEffect(() => {
+    startTimeRef.current = startTime;
+    endTimeRef.current = endTime;
+  }, [endTime, startTime, conversation]);
+
+  const getMessages = useCallback(
+    async (initial?: boolean) => {
+      // client and conversation are required
+      if (!client || !conversation) {
+        return;
+      }
+
+      const cId = getConversationId(conversation);
+
+      try {
+        // get cached messages and decode them
+        const decodedMessages = await getCachedMessages({
+          cId,
+          client,
+          direction,
+          initial,
+          lastEntry: lastCacheEntryRef.current,
+          limit,
+        });
+
+        setMessages(decodedMessages);
+
+        updateLastEntry({
+          direction,
+          endTimeRef,
+          startTimeRef,
+          lastEntry: decodedMessages[decodedMessages.length - 1],
+          lastEntryRef: lastCacheEntryRef,
+        });
+
+        // only fetch more messages from the network if necessary
+        // no limit specified, or
+        // number of cached messages is less than the limit
+        if (!(!limit || (limit && decodedMessages.length < limit))) {
+          return;
+        }
+
+        let finalLimit = limit;
+        if (limit && decodedMessages.length < limit) {
+          finalLimit = limit - decodedMessages.length;
+        }
+
+        const finalOptions = {
+          checkAddresses,
+          direction,
+          endTime: endTimeRef.current,
+          limit: finalLimit,
+          startTime: startTimeRef.current,
+        };
+
+        setIsLoading(true);
+
+        const networkMessages = await conversation.messages(finalOptions);
+
+        networkMessages.forEach((m) => {
+          void messagesDb.persistMessage(m);
+        });
+
+        if (networkMessages.length > 0) {
+          updateLastEntry({
+            direction,
+            endTimeRef,
+            startTimeRef,
+            lastEntry: networkMessages[networkMessages.length - 1],
+            lastEntryRef: lastCacheEntryRef,
+          });
+        }
+
+        const newMessages: DecodedMessage[] = [
+          ...decodedMessages,
+          ...networkMessages,
+        ];
+
+        setMessages(newMessages);
+        onMessages?.(newMessages, finalOptions);
+
+        if (limit) {
+          setHasMore(newMessages.length > 0 && newMessages.length === limit);
+        }
+      } catch (e) {
+        setError(e);
+        onError?.(e);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [
+      checkAddresses,
+      client,
+      conversation,
+      direction,
+      limit,
+      onError,
+      onMessages,
+    ],
+  );
+
+  // fetch the next set of messages
+  const next = useCallback(async () => getMessages(), [getMessages]);
+
+  // fetch conversation messages on mount
+  useEffect(() => {
+    void getMessages(true);
+  }, [getMessages]);
+
+  return {
+    error,
+    hasMore,
+    isLoading,
+    messages,
+    next,
+  };
+};

--- a/packages/react-sdk/src/hooks/useConversations.ts
+++ b/packages/react-sdk/src/hooks/useConversations.ts
@@ -1,6 +1,6 @@
 import type { Conversation } from "@xmtp/xmtp-js";
-import { useContext, useEffect, useState } from "react";
-import { XMTPContext } from "../contexts/XMTPContext";
+import { useEffect, useState } from "react";
+import { useClient } from "./useClient";
 
 export type UseConversationsOptions = {
   /**
@@ -21,19 +21,15 @@ export const useConversations = (options?: UseConversationsOptions) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<unknown | null>(null);
   const [conversations, setConversations] = useState<Conversation[]>([]);
+  const { client } = useClient();
 
   // destructure options for more granular dependency arrays
   const { onConversations, onError } = options ?? {};
 
-  const xmtpContext = useContext(XMTPContext);
-  if (xmtpContext === undefined) {
-    console.error("useConversations must be used within a XMTPProvider");
-  }
-
   // attempt to fetch conversations on mount
   useEffect(() => {
     // we can't do anything without a client
-    if (xmtpContext?.client === undefined) {
+    if (client === undefined) {
       console.error("XMTP client is not available");
       return;
     }
@@ -42,8 +38,7 @@ export const useConversations = (options?: UseConversationsOptions) => {
       setIsLoading(true);
 
       try {
-        const conversationList =
-          (await xmtpContext.client?.conversations.list()) ?? [];
+        const conversationList = (await client?.conversations.list()) ?? [];
         setConversations(conversationList);
         onConversations?.(conversationList);
       } catch (e) {
@@ -55,7 +50,7 @@ export const useConversations = (options?: UseConversationsOptions) => {
     };
 
     void getConversations();
-  }, [onConversations, onError, xmtpContext.client]);
+  }, [onConversations, onError, client]);
 
   return {
     conversations,

--- a/packages/react-sdk/src/hooks/useStartConversation.ts
+++ b/packages/react-sdk/src/hooks/useStartConversation.ts
@@ -1,6 +1,6 @@
-import { useCallback, useContext } from "react";
+import { useCallback } from "react";
 import type { SendOptions, InvitationContext } from "@xmtp/xmtp-js";
-import { XMTPContext } from "../contexts/XMTPContext";
+import { useClient } from "./useClient";
 
 /**
  * This hook starts a new conversation and sends an initial message to it.
@@ -8,10 +8,7 @@ import { XMTPContext } from "../contexts/XMTPContext";
 export const useStartConversation = <T = string>(
   options?: InvitationContext,
 ) => {
-  const xmtpContext = useContext(XMTPContext);
-  if (xmtpContext === undefined) {
-    console.error("useStartConversation must be used within a XMTPProvider");
-  }
+  const { client } = useClient();
 
   // destructure options for more granular dependency arrays
   const { conversationId, metadata } = options ?? {};
@@ -19,26 +16,25 @@ export const useStartConversation = <T = string>(
   return useCallback(
     async (peerAddress: string, message: T, sendOptions?: SendOptions) => {
       // we can't do anything without a client
-      if (xmtpContext?.client === undefined) {
+      if (client === undefined) {
         console.error("XMTP client is not available");
         return undefined;
       }
 
-      const conversation =
-        await xmtpContext?.client?.conversations.newConversation(
-          peerAddress,
-          conversationId && metadata
-            ? {
-                conversationId,
-                metadata,
-              }
-            : undefined,
-        );
+      const conversation = await client?.conversations.newConversation(
+        peerAddress,
+        conversationId && metadata
+          ? {
+              conversationId,
+              metadata,
+            }
+          : undefined,
+      );
 
       await conversation.send(message, sendOptions);
 
       return conversation;
     },
-    [conversationId, metadata, xmtpContext?.client],
+    [conversationId, metadata, client],
   );
 };

--- a/packages/react-sdk/src/hooks/useStreamAllMessages.ts
+++ b/packages/react-sdk/src/hooks/useStreamAllMessages.ts
@@ -1,6 +1,6 @@
 import type { DecodedMessage } from "@xmtp/xmtp-js";
-import { useContext, useEffect, useRef, useState } from "react";
-import { XMTPContext } from "../contexts/XMTPContext";
+import { useEffect, useRef, useState } from "react";
+import { useClient } from "./useClient";
 
 export type AllMessagesStream = Promise<AsyncGenerator<DecodedMessage>>;
 
@@ -24,10 +24,7 @@ export const useStreamAllMessages = (
     }
   });
 
-  const xmtpContext = useContext(XMTPContext);
-  if (xmtpContext === undefined) {
-    console.error("useStreamAllMessages must be used within a XMTPProvider");
-  }
+  const { client } = useClient();
 
   // attempt to stream conversation messages on mount
   useEffect(() => {
@@ -38,7 +35,7 @@ export const useStreamAllMessages = (
 
     const streamAllMessages = async () => {
       // we can't do anything without a client
-      if (xmtpContext?.client === undefined) {
+      if (client === undefined) {
         console.error("XMTP client is not initialized");
         return;
       }
@@ -51,8 +48,7 @@ export const useStreamAllMessages = (
       try {
         // it's important not to await the stream here so that we can cleanup
         // consistently if this hook unmounts during this call
-        streamRef.current =
-          xmtpContext.client.conversations.streamAllMessages();
+        streamRef.current = client.conversations.streamAllMessages();
         stream = streamRef.current;
 
         for await (const message of await stream) {
@@ -70,7 +66,7 @@ export const useStreamAllMessages = (
     return () => {
       void endStream(stream);
     };
-  }, [onMessage, xmtpContext.client]);
+  }, [onMessage, client]);
 
   return {
     error,

--- a/packages/react-sdk/src/hooks/useStreamConversations.ts
+++ b/packages/react-sdk/src/hooks/useStreamConversations.ts
@@ -1,6 +1,6 @@
 import type { Conversation, Stream } from "@xmtp/xmtp-js";
-import { useContext, useEffect, useRef, useState } from "react";
-import { XMTPContext } from "../contexts/XMTPContext";
+import { useEffect, useRef, useState } from "react";
+import { useClient } from "./useClient";
 
 export type ConversationStream = Promise<Stream<Conversation>>;
 
@@ -24,10 +24,7 @@ export const useStreamConversations = (
     }
   });
 
-  const xmtpContext = useContext(XMTPContext);
-  if (xmtpContext === undefined) {
-    console.error("useStreamConversations must be used within a XMTPProvider");
-  }
+  const { client } = useClient();
 
   /**
    * Attempt to stream conversations on mount
@@ -39,7 +36,7 @@ export const useStreamConversations = (
 
     const streamConversations = async () => {
       // we can't do anything without a client
-      if (xmtpContext?.client === undefined) {
+      if (client === undefined) {
         console.error("XMTP client is not available");
         return;
       }
@@ -52,7 +49,7 @@ export const useStreamConversations = (
       try {
         // it's important not to await the stream here so that we can cleanup
         // consistently if this hook unmounts during this call
-        streamRef.current = xmtpContext.client.conversations.stream();
+        streamRef.current = client.conversations.stream();
         stream = streamRef.current;
 
         for await (const conversation of await stream) {
@@ -70,7 +67,7 @@ export const useStreamConversations = (
     return () => {
       void endStream(stream);
     };
-  }, [onConversation, xmtpContext.client]);
+  }, [onConversation, client]);
 
   return {
     error,

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -8,6 +8,7 @@ export { isValidAddress } from "./helpers/isValidAddress";
 export { useCanMessage } from "./hooks/useCanMessage";
 export { useConversations } from "./hooks/useConversations";
 export { useClient } from "./hooks/useClient";
+export { useCachedMessages } from "./hooks/useCachedMessages";
 export { useMessages } from "./hooks/useMessages";
 export { useSendMessage } from "./hooks/useSendMessage";
 export { useStartConversation } from "./hooks/useStartConversation";

--- a/yarn.lock
+++ b/yarn.lock
@@ -6631,11 +6631,13 @@ __metadata:
     "@xmtp/tsconfig": "workspace:*"
     "@xmtp/xmtp-js": ^9.0.1
     date-fns: ^2.30.0
+    dexie: ^3.2.3
     eslint: ^8.40.0
     eslint-config-xmtp-web: "workspace:*"
     jsdom: ^21.1.2
     prettier: ^2.8.8
     react: ^18.2.0
+    react-18-blockies: ^1.0.6
     react-dom: ^18.2.0
     tsup: ^6.7.0
     typescript: ^5.0.4
@@ -8454,6 +8456,13 @@ __metadata:
     detect: bin/detect-port.js
     detect-port: bin/detect-port.js
   checksum: b48da9340481742547263d5d985e65d078592557863402ecf538511735e83575867e94f91fe74405ea19b61351feb99efccae7e55de9a151d5654e3417cea05b
+  languageName: node
+  linkType: hard
+
+"dexie@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "dexie@npm:3.2.3"
+  checksum: 54fd7bc94364ed601dc2d53f8b488e49ac61d4ec532f001a68fde9ffccb4bf3c6a8af310b41d8f52c94c1a99c0e165437d7b223b655df582ceda90b9bfcd60e7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6637,7 +6637,6 @@ __metadata:
     jsdom: ^21.1.2
     prettier: ^2.8.8
     react: ^18.2.0
-    react-18-blockies: ^1.0.6
     react-dom: ^18.2.0
     tsup: ^6.7.0
     typescript: ^5.0.4


### PR DESCRIPTION
This PR adds message caching via IndexedDB in a browser when using the new `useCachedMessages` hook. The new hook has the same API as the `useMessages` hook, but will add messages to a cache and attempt to fetch messages from the cache before accessing the network.

It also optimizes the existing `useMessages` hook to match some of the new logic in the `useCachedMessages` hook.