### PR TITLE
Make error handling consistent across all hooks

### DIFF
--- a/examples/react-quickstart/src/components/Messages.tsx
+++ b/examples/react-quickstart/src/components/Messages.tsx
@@ -35,7 +35,7 @@ export const Messages: React.FC<ConversationMessagesProps> = ({
     [streamedMessages],
   );
   useStreamMessages(conversation, onMessage);
-  const sendMessage = useSendMessage(conversation);
+  const { sendMessage } = useSendMessage(conversation);
 
   const handleSendMessage = useCallback(
     async (message: string) => {

--- a/examples/react-quickstart/src/components/NewMessage.tsx
+++ b/examples/react-quickstart/src/components/NewMessage.tsx
@@ -22,7 +22,7 @@ export const NewMessage: React.FC<NewMessageProps> = ({ onSuccess }) => {
   const [isOnNetwork, setIsOnNetwork] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  const startConversation = useStartConversation();
+  const { startConversation } = useStartConversation();
   const { canMessage } = useCanMessage();
 
   const handleChange = useCallback((updatedValue: string) => {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xmtp/react-sdk",
   "description": "XMTP client SDK for React apps written in TypeScript",
-  "version": "1.0.0-preview.31",
+  "version": "1.0.0-preview.32",
   "license": "MIT",
   "type": "module",
   "main": "lib/index.cjs",

--- a/packages/react-sdk/src/contexts/XMTPContext.tsx
+++ b/packages/react-sdk/src/contexts/XMTPContext.tsx
@@ -1,6 +1,7 @@
 import { useState, createContext, useCallback, useMemo, useRef } from "react";
 import type { ClientOptions, Signer } from "@xmtp/xmtp-js";
 import { Client } from "@xmtp/xmtp-js";
+import type { OnError } from "../sharedTypes";
 
 type CanMessageReturns<T> = T extends string
   ? boolean
@@ -10,7 +11,7 @@ type CanMessageReturns<T> = T extends string
 
 export type InitClientArgs = {
   keys?: Uint8Array;
-  options?: Partial<ClientOptions>;
+  options?: Partial<ClientOptions> & OnError;
   signer?: Signer | null;
 };
 
@@ -96,7 +97,8 @@ export const XMTPProvider: React.FC<React.PropsWithChildren> = ({
           setClient(undefined);
           setClientSigner(undefined);
           setError(e);
-          // re-throw error so that consumers can process
+          options?.onError?.(e);
+          // re-throw error for upstream consumption
           throw e;
         } finally {
           setIsLoading(false);

--- a/packages/react-sdk/src/hooks/useCachedMessages.ts
+++ b/packages/react-sdk/src/hooks/useCachedMessages.ts
@@ -8,6 +8,7 @@ import { getConversationId } from "../helpers/getConversationId";
 import { useClient } from "./useClient";
 import { updateLastEntry } from "../helpers/updateLastEntry";
 import { adjustDate } from "../helpers/adjustDate";
+import type { OnError } from "../sharedTypes";
 
 type GetCachedMessagesOptions = {
   /**
@@ -84,19 +85,16 @@ const getCachedMessages = async ({
   );
 };
 
-export type UseCachedMessagesOptions = ListMessagesOptions & {
-  /**
-   * Callback function to execute when new messages are fetched
-   */
-  onMessages?: (
-    messages: DecodedMessage[],
-    options: ListMessagesOptions,
-  ) => void;
-  /**
-   * Callback function to execute when an error occurs
-   */
-  onError?: (error: unknown) => void;
-};
+export type UseCachedMessagesOptions = ListMessagesOptions &
+  OnError & {
+    /**
+     * Callback function to execute when new messages are fetched
+     */
+    onMessages?: (
+      messages: DecodedMessage[],
+      options: ListMessagesOptions,
+    ) => void;
+  };
 
 /**
  * This hook fetches a list of all messages within a conversation on mount,
@@ -144,6 +142,7 @@ export const useCachedMessages = (
       }
 
       const cId = getConversationId(conversation);
+      setError(null);
 
       try {
         // get cached messages and decode them
@@ -218,6 +217,8 @@ export const useCachedMessages = (
       } catch (e) {
         setError(e);
         onError?.(e);
+        // re-throw error for upstream consumption
+        throw e;
       } finally {
         setIsLoading(false);
       }

--- a/packages/react-sdk/src/hooks/useCanMessage.ts
+++ b/packages/react-sdk/src/hooks/useCanMessage.ts
@@ -1,19 +1,71 @@
-import { useContext } from "react";
+import { useCallback, useContext, useState } from "react";
 import { Client } from "@xmtp/xmtp-js";
 import { XMTPContext } from "../contexts/XMTPContext";
+import type { OnError } from "../sharedTypes";
 
 /**
  * This hook exposes both the client and static instances of the `canMessage`
  * method.
  */
-export const useCanMessage = () => {
+export const useCanMessage = (onError?: OnError["onError"]) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<unknown | null>(null);
   const xmtpContext = useContext(XMTPContext);
 
+  if (xmtpContext === undefined) {
+    console.error("This hook must be used within the context of XMTPProvider");
+  }
+
+  const { canMessage: cm } = xmtpContext;
+
+  /**
+   * Check if a wallet address is on the XMTP network using the client instance
+   */
+  const canMessage = useCallback(
+    async (...args: Parameters<typeof cm>) => {
+      setIsLoading(false);
+      setError(null);
+
+      try {
+        await cm(...args);
+      } catch (e) {
+        setError(e);
+        onError?.(e);
+        // re-throw error for upstream consumption
+        throw e;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [cm, onError],
+  );
+
+  /**
+   * Check if a wallet address is on the XMTP network without a client instance
+   */
+  const canMessageStatic = useCallback(
+    async (...args: Parameters<typeof Client.canMessage>) => {
+      setIsLoading(false);
+      setError(null);
+
+      try {
+        await Client.canMessage(...args);
+      } catch (e) {
+        setError(e);
+        onError?.(e);
+        // re-throw error for upstream consumption
+        throw e;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [onError],
+  );
+
   return {
-    canMessage: xmtpContext.canMessage,
-    /**
-     * Check if a wallet address is on the XMTP network without a client instance
-     */
-    canMessageStatic: Client.canMessage,
+    error,
+    isLoading,
+    canMessage,
+    canMessageStatic,
   };
 };

--- a/packages/react-sdk/src/hooks/useCanMessage.ts
+++ b/packages/react-sdk/src/hooks/useCanMessage.ts
@@ -21,13 +21,13 @@ export const useCanMessage = (onError?: OnError["onError"]) => {
   /**
    * Check if a wallet address is on the XMTP network using the client instance
    */
-  const canMessage = useCallback(
-    async (...args: Parameters<typeof cm>) => {
+  const canMessage = useCallback<typeof cm>(
+    async (peerAddress) => {
       setIsLoading(false);
       setError(null);
 
       try {
-        await cm(...args);
+        return await cm(peerAddress);
       } catch (e) {
         setError(e);
         onError?.(e);
@@ -49,7 +49,7 @@ export const useCanMessage = (onError?: OnError["onError"]) => {
       setError(null);
 
       try {
-        await Client.canMessage(...args);
+        return await Client.canMessage(...args);
       } catch (e) {
         setError(e);
         onError?.(e);

--- a/packages/react-sdk/src/hooks/useClient.ts
+++ b/packages/react-sdk/src/hooks/useClient.ts
@@ -8,7 +8,7 @@ import { XMTPContext } from "../contexts/XMTPContext";
 export const useClient = () => {
   const xmtpContext = useContext(XMTPContext);
   if (xmtpContext === undefined) {
-    console.error("useClient must be used within a XMTPProvider");
+    console.error("This hook must be used within the context of XMTPProvider");
   }
 
   return {

--- a/packages/react-sdk/src/hooks/useMessages.ts
+++ b/packages/react-sdk/src/hooks/useMessages.ts
@@ -5,20 +5,18 @@ import type {
 } from "@xmtp/xmtp-js";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { updateLastEntry } from "../helpers/updateLastEntry";
+import type { OnError } from "../sharedTypes";
 
-export type UseMessagesOptions = ListMessagesOptions & {
-  /**
-   * Callback function to execute when new messages are fetched
-   */
-  onMessages?: (
-    messages: DecodedMessage[],
-    options: ListMessagesOptions,
-  ) => void;
-  /**
-   * Callback function to execute when an error occurs
-   */
-  onError?: (error: unknown) => void;
-};
+export type UseMessagesOptions = ListMessagesOptions &
+  OnError & {
+    /**
+     * Callback function to execute when new messages are fetched
+     */
+    onMessages?: (
+      messages: DecodedMessage[],
+      options: ListMessagesOptions,
+    ) => void;
+  };
 
 /**
  * This hook fetches a list of all messages within a conversation on mount. It
@@ -68,6 +66,7 @@ export const useMessages = (
     }
 
     setIsLoading(true);
+    setError(null);
 
     const finalOptions = {
       checkAddresses,
@@ -103,6 +102,8 @@ export const useMessages = (
     } catch (e) {
       setError(e);
       onError?.(e);
+      // re-throw error for upstream consumption
+      throw e;
     } finally {
       setIsLoading(false);
     }

--- a/packages/react-sdk/src/sharedTypes.ts
+++ b/packages/react-sdk/src/sharedTypes.ts
@@ -1,0 +1,6 @@
+export type OnError = {
+  /**
+   * Callback function to execute when an error occurs
+   */
+  onError?: (error: unknown | Error) => void;
+};


### PR DESCRIPTION
To ensure a consistent and flexible error handling experience for every hook, this update allows for consumers to process errors in 3 ways:

* `try/catch` blocks
* `onError` callbacks
* `error` state returned by the hook