### PR TITLE
Fix `canMessageStatic` type

### DIFF
--- a/packages/react-sdk/src/contexts/XMTPContext.tsx
+++ b/packages/react-sdk/src/contexts/XMTPContext.tsx
@@ -1,13 +1,7 @@
 import { useState, createContext, useCallback, useMemo, useRef } from "react";
 import type { ClientOptions, Signer } from "@xmtp/xmtp-js";
 import { Client } from "@xmtp/xmtp-js";
-import type { OnError } from "../sharedTypes";
-
-type CanMessageReturns<T> = T extends string
-  ? boolean
-  : T extends string[]
-  ? boolean[]
-  : never;
+import type { CanMessageReturns, OnError } from "../sharedTypes";
 
 export type InitClientArgs = {
   keys?: Uint8Array;

--- a/packages/react-sdk/src/hooks/useCanMessage.ts
+++ b/packages/react-sdk/src/hooks/useCanMessage.ts
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useState } from "react";
 import { Client } from "@xmtp/xmtp-js";
 import { XMTPContext } from "../contexts/XMTPContext";
-import type { OnError } from "../sharedTypes";
+import type { CanMessageReturns, OnError } from "../sharedTypes";
 
 /**
  * This hook exposes both the client and static instances of the `canMessage`
@@ -44,12 +44,21 @@ export const useCanMessage = (onError?: OnError["onError"]) => {
    * Check if a wallet address is on the XMTP network without a client instance
    */
   const canMessageStatic = useCallback(
-    async (...args: Parameters<typeof Client.canMessage>) => {
+    async <T extends string | string[]>(
+      peerAddress: T,
+      options?: Parameters<typeof Client.canMessage>["1"],
+    ): Promise<CanMessageReturns<T>> => {
       setIsLoading(false);
       setError(null);
 
       try {
-        return await Client.canMessage(...args);
+        return typeof peerAddress === "string"
+          ? await (Client.canMessage(peerAddress, options) as Promise<
+              CanMessageReturns<T>
+            >)
+          : await (Client.canMessage(peerAddress, options) as Promise<
+              CanMessageReturns<T>
+            >);
       } catch (e) {
         setError(e);
         onError?.(e);

--- a/packages/react-sdk/src/sharedTypes.ts
+++ b/packages/react-sdk/src/sharedTypes.ts
@@ -4,3 +4,9 @@ export type OnError = {
    */
   onError?: (error: unknown | Error) => void;
 };
+
+export type CanMessageReturns<T> = T extends string
+  ? boolean
+  : T extends string[]
+  ? boolean[]
+  : never;


### PR DESCRIPTION
After updating the `useCanMessage` hook with better error handling, the original (and correct) type for `canMessageStatic` got lost. This PR fixes the type.