### PR TITLE
Add message content validators, update code comments

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -82,7 +82,8 @@
     "dexie": "^3.2.4",
     "dexie-react-hooks": "^1.1.6",
     "react": "^18.2.0",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "zod": "^3.22.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.0.0",

--- a/packages/react-sdk/src/helpers/caching/contentTypes/attachment.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/attachment.ts
@@ -9,6 +9,7 @@ import {
   RemoteAttachmentCodec,
 } from "@xmtp/content-type-remote-attachment";
 import { ContentTypeId } from "@xmtp/xmtp-js";
+import { z } from "zod";
 import type { CacheConfiguration, CachedMessageProcessor } from "../db";
 import { type CachedMessage } from "../messages";
 
@@ -16,20 +17,57 @@ const NAMESPACE = "attachment";
 
 export type CachedAttachmentsMetadata = Attachment | undefined;
 
-export const hasAttachment = (message: CachedMessage) => {
-  const metadata = message?.metadata?.[NAMESPACE] as CachedAttachmentsMetadata;
-  return !!metadata;
-};
-
+/**
+ * Get the attachment data from a cached message
+ *
+ * @param message Cached message
+ * @returns The attachment data, or `undefined` if the message has no attachment
+ */
 export const getAttachment = (message: CachedMessage) =>
   message?.metadata?.[NAMESPACE] as CachedAttachmentsMetadata;
 
+/**
+ * Check if a cached message has an attachment
+ *
+ * @param message Cached message
+ * @returns `true` if the message has an attachment, `false` otherwise
+ */
+export const hasAttachment = (message: CachedMessage) => {
+  const attachment = getAttachment(message);
+  return !!attachment;
+};
+
+const AttachmentContentSchema = z.object({
+  filename: z.string(),
+  mimeType: z.string(),
+  data: z.instanceof(Uint8Array),
+});
+
+/**
+ * Validate the content of an attachment message
+ *
+ * @param content Message content
+ * @returns `true` if the content is valid, `false` otherwise
+ */
+const isValidAttachmentContent = (content: unknown) => {
+  const { success } = AttachmentContentSchema.safeParse(content);
+  return success;
+};
+
+/**
+ * Process an attachment message
+ *
+ * The message content is also saved to the metadata of the message.
+ */
 export const processAttachment: CachedMessageProcessor = async ({
   message,
   persist,
 }) => {
   const contentType = ContentTypeId.fromString(message.contentType);
-  if (ContentTypeAttachment.sameAs(contentType)) {
+  if (
+    ContentTypeAttachment.sameAs(contentType) &&
+    isValidAttachmentContent(message.content)
+  ) {
     // save message to cache with the attachment metadata
     await persist({
       metadata: message.content as Attachment,
@@ -37,13 +75,44 @@ export const processAttachment: CachedMessageProcessor = async ({
   }
 };
 
+const RemoveAttachmentContentSchema = z.object({
+  url: z.string(),
+  contentDigest: z.string(),
+  salt: z.instanceof(Uint8Array),
+  nonce: z.instanceof(Uint8Array),
+  secret: z.instanceof(Uint8Array),
+  scheme: z.string(),
+  contentLength: z.number().gte(0),
+  filename: z.string(),
+});
+
+/**
+ * Validate the content of a remote attachment message
+ *
+ * @param content Message content
+ * @returns `true` if the content is valid, `false` otherwise
+ */
+const isValidRemoveAttachmentContent = (content: unknown) => {
+  const { success } = RemoveAttachmentContentSchema.safeParse(content);
+  return success;
+};
+
+/**
+ * Process a remote attachment message
+ *
+ * Loads the attachment from the remote URL and saves it to the metadata
+ * of the message.
+ */
 export const processRemoteAttachment: CachedMessageProcessor = async ({
   client,
   message,
   persist,
 }) => {
   const contentType = ContentTypeId.fromString(message.contentType);
-  if (ContentTypeRemoteAttachment.sameAs(contentType)) {
+  if (
+    ContentTypeRemoteAttachment.sameAs(contentType) &&
+    isValidRemoveAttachmentContent(message.content)
+  ) {
     const attachment = await RemoteAttachmentCodec.load<Attachment>(
       message.content as RemoteAttachment,
       client,
@@ -62,5 +131,9 @@ export const attachmentsCacheConfig: CacheConfiguration = {
   processors: {
     [ContentTypeAttachment.toString()]: [processAttachment],
     [ContentTypeRemoteAttachment.toString()]: [processRemoteAttachment],
+  },
+  validators: {
+    [ContentTypeAttachment.toString()]: isValidAttachmentContent,
+    [ContentTypeRemoteAttachment.toString()]: isValidRemoveAttachmentContent,
   },
 };

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reaction.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reaction.test.ts
@@ -94,7 +94,7 @@ describe("ContentTypeReaction caching", () => {
         xmtpID: "testXmtpId1",
       } satisfies CachedMessageWithId;
 
-      await saveMessage({ db, message: testTextMessage });
+      await saveMessage(testTextMessage, db);
 
       const testReactionContent = {
         content: "test",

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reply.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reply.test.ts
@@ -65,7 +65,7 @@ describe("ContentTypeReply caching", () => {
         xmtpID: "testXmtpId1",
       } satisfies CachedMessageWithId;
 
-      await saveMessage({ db, message: testTextMessage });
+      await saveMessage(testTextMessage, db);
 
       const testReplyContent = {
         content: "test",
@@ -101,7 +101,7 @@ describe("ContentTypeReply caching", () => {
       });
       expect(persist).toHaveBeenCalledWith();
       // since we mocked persist, we need to manually save the message
-      await saveMessage({ db, message: testReplyMessage });
+      await saveMessage(testReplyMessage, db);
 
       const originalMessage = await getMessageByXmtpID("testXmtpId1", db);
       const replies = getReplies(originalMessage!);
@@ -247,7 +247,7 @@ describe("ContentTypeReply caching", () => {
         xmtpID: "testXmtpId1",
       } satisfies CachedMessageWithId;
 
-      await saveMessage({ db, message: testTextMessage });
+      await saveMessage(testTextMessage, db);
       await addReply("testXmtpId1", "testXmtpId2", db);
       await addReply("testXmtpId1", "testXmtpId3", db);
 

--- a/packages/react-sdk/src/helpers/caching/contentTypes/text.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/text.ts
@@ -3,12 +3,28 @@ import type { CacheConfiguration, CachedMessageProcessor } from "../db";
 
 const NAMESPACE = "text";
 
+/**
+ * Validate the content of a text message
+ *
+ * @param content Message content
+ * @returns `true` if the content is valid, `false` otherwise
+ */
+const isValidTextContent = (content: unknown) => typeof content === "string";
+
+/**
+ * Process a text message
+ *
+ * Saves the message to the cache.
+ */
 export const processText: CachedMessageProcessor = async ({
   message,
   persist,
 }) => {
   const contentType = ContentTypeId.fromString(message.contentType);
-  if (ContentTypeText.sameAs(contentType)) {
+  if (
+    ContentTypeText.sameAs(contentType) &&
+    isValidTextContent(message.content)
+  ) {
     // no special processing, just persist the message to cache
     await persist();
   }
@@ -18,5 +34,8 @@ export const textCacheConfig: CacheConfiguration = {
   namespace: NAMESPACE,
   processors: {
     [ContentTypeText.toString()]: [processText],
+  },
+  validators: {
+    [ContentTypeText.toString()]: isValidTextContent,
   },
 };

--- a/packages/react-sdk/src/helpers/caching/db.ts
+++ b/packages/react-sdk/src/helpers/caching/db.ts
@@ -44,11 +44,17 @@ export type CachedMessageProcessor<C = any> = (options: {
   updateConversationMetadata: (data: CachedMetadataValues) => Promise<void>;
 }) => Promise<void>;
 
+export type CachedMessageValidators = Record<
+  string,
+  (content: unknown) => boolean
+>;
+
 export type CacheConfiguration = {
   codecs?: ContentCodec<any>[];
   namespace: string;
   processors: CachedMessageProcessors;
   schema?: Record<string, string>;
+  validators?: CachedMessageValidators;
 };
 
 export type CachedMessageProcessors = {
@@ -95,7 +101,6 @@ export const getDbInstance = (options?: GetDBInstanceOptions) => {
       contentFallback,
       contentType,
       conversationTopic,
-      hasSendError,
       senderAddress,
       sentAt,
       status,

--- a/packages/react-sdk/src/helpers/caching/messages.test.ts
+++ b/packages/react-sdk/src/helpers/caching/messages.test.ts
@@ -598,7 +598,6 @@ describe("processMessage", () => {
       peerAddress: "testPeerAddress",
       walletAddress: "testWalletAddress",
     } satisfies CachedConversation;
-    // const cachedConversation = await saveConversation(testConversation, db);
     const sentAt = adjustDate(createdAt, 1000);
     const testMessage = {
       id: 1,
@@ -614,7 +613,6 @@ describe("processMessage", () => {
       uuid: "testUuid",
       xmtpID: "testXmtpId",
     } satisfies CachedMessage;
-    // await saveMessage(testMessage, db);
     const cachedMessage = await processMessage({
       client: testClient,
       conversation: testConversation,

--- a/packages/react-sdk/src/helpers/combineMessageProcessors.ts
+++ b/packages/react-sdk/src/helpers/combineMessageProcessors.ts
@@ -5,7 +5,7 @@ import type {
 } from "@/helpers/caching/db";
 
 /**
- * Formats message processors for easy consumption
+ * Combines all message processors into a single object
  *
  * @param cacheConfig The cache configuration to extract the processors from
  * @returns An object that maps content types to their respective message processors

--- a/packages/react-sdk/src/helpers/combineNamespaces.ts
+++ b/packages/react-sdk/src/helpers/combineNamespaces.ts
@@ -4,7 +4,7 @@ import {
 } from "@/helpers/caching/db";
 
 /**
- * Formats namespaces for easy consumption
+ * Combines all namespaces into a single object
  *
  * @param cacheConfig The cache configuration to extract the namespaces from
  * @returns An object that maps content types to their respective namespace

--- a/packages/react-sdk/src/helpers/combineValidators.test.ts
+++ b/packages/react-sdk/src/helpers/combineValidators.test.ts
@@ -1,0 +1,47 @@
+import { it, expect, describe } from "vitest";
+import { ContentTypeText } from "@xmtp/xmtp-js";
+import { combineValidators } from "@/helpers/combineValidators";
+import { attachmentsCacheConfig } from "@/helpers/caching/contentTypes/attachment";
+import { reactionsCacheConfig } from "@/helpers/caching/contentTypes/reaction";
+import { readReceiptsCacheConfig } from "@/helpers/caching/contentTypes/readReceipt";
+import { repliesCacheConfig } from "@/helpers/caching/contentTypes/reply";
+import { textCacheConfig } from "@/helpers/caching/contentTypes/text";
+
+const testCacheConfig = [
+  attachmentsCacheConfig,
+  reactionsCacheConfig,
+  readReceiptsCacheConfig,
+  repliesCacheConfig,
+];
+
+describe("combineValidators", () => {
+  it("should combine content validators from a cache config", () => {
+    expect(combineValidators(testCacheConfig)).toEqual({
+      ...attachmentsCacheConfig.validators,
+      ...reactionsCacheConfig.validators,
+      ...readReceiptsCacheConfig.validators,
+      ...repliesCacheConfig.validators,
+      ...textCacheConfig.validators,
+    });
+  });
+
+  it("should only have a text content validator without a cache config", () => {
+    expect(combineValidators()).toEqual(textCacheConfig.validators);
+  });
+
+  it("should throw when there's a duplicate content type validator", () => {
+    expect(() =>
+      combineValidators([
+        {
+          namespace: "foo",
+          processors: {},
+          validators: {
+            [ContentTypeText.toString()]: () => false,
+          },
+        },
+      ]),
+    ).toThrow(
+      `Duplicate content validator detected for content type "${ContentTypeText.toString()}"`,
+    );
+  });
+});

--- a/packages/react-sdk/src/helpers/combineValidators.ts
+++ b/packages/react-sdk/src/helpers/combineValidators.ts
@@ -1,0 +1,37 @@
+import { defaultCacheConfig } from "@/helpers/caching/db";
+import type {
+  CachedMessageValidators,
+  CacheConfiguration,
+} from "@/helpers/caching/db";
+
+/**
+ * Combines all content validators into a single object
+ *
+ * @param cacheConfig The cache configuration to extract the content validators from
+ * @returns An object that maps content types to their respective content validator
+ */
+export const combineValidators = (cacheConfig?: CacheConfiguration[]) => {
+  // merge default config with passed in config
+  const finalCacheConfig = [...defaultCacheConfig, ...(cacheConfig ?? [])];
+  // array of validator content types for detecting duplicates
+  const validatorContentTypes: string[] = [];
+  return finalCacheConfig.reduce((result, config) => {
+    const validators: CachedMessageValidators = {};
+    // prevent duplicate content type validators
+    Object.entries(config.validators ?? {}).forEach(
+      ([contentType, validator]) => {
+        if (validatorContentTypes.includes(contentType)) {
+          throw new Error(
+            `Duplicate content validator detected for content type "${contentType}"`,
+          );
+        }
+        validatorContentTypes.push(contentType);
+        validators[contentType] = validator;
+      },
+    );
+    return {
+      ...result,
+      ...validators,
+    };
+  }, {} as CachedMessageValidators);
+};

--- a/packages/react-sdk/src/hooks/useCachedMessages.test.ts
+++ b/packages/react-sdk/src/hooks/useCachedMessages.test.ts
@@ -56,7 +56,7 @@ describe("useCachedMessages", () => {
       xmtpID: "testXmtpId",
     } satisfies CachedMessage;
 
-    await saveMessage({ db, message: testMessage });
+    await saveMessage(testMessage, db);
 
     const { result } = renderHook(() => useCachedMessages(testTopic));
 

--- a/packages/react-sdk/src/hooks/useClient.ts
+++ b/packages/react-sdk/src/hooks/useClient.ts
@@ -45,6 +45,7 @@ export const useClient = (onError?: OnError["onError"]) => {
     db,
     processors,
     namespaces,
+    validators,
   } = useContext(XMTPContext);
 
   /**
@@ -123,6 +124,7 @@ export const useClient = (onError?: OnError["onError"]) => {
             db,
             processors,
             namespaces,
+            validators,
           });
           processedRef.current = true;
         } catch (e) {
@@ -134,7 +136,7 @@ export const useClient = (onError?: OnError["onError"]) => {
       };
       void reprocess();
     }
-  }, [client, db, namespaces, onError, processors]);
+  }, [client, db, namespaces, onError, processors, validators]);
 
   return {
     client,

--- a/packages/react-sdk/src/hooks/useLastMessage.test.ts
+++ b/packages/react-sdk/src/hooks/useLastMessage.test.ts
@@ -56,7 +56,7 @@ describe("useLastMessage", () => {
       xmtpID: "testXmtpId",
     } satisfies CachedMessage;
 
-    await saveMessage({ db, message: testMessage });
+    await saveMessage(testMessage, db);
 
     const { result } = renderHook(() => useLastMessage(testTopic));
 

--- a/packages/react-sdk/src/hooks/useMessage.ts
+++ b/packages/react-sdk/src/hooks/useMessage.ts
@@ -30,7 +30,7 @@ export type SendMessageOptions = Omit<SendOptions, "contentType"> &
  */
 export const useMessage = () => {
   const xmtpContext = useContext(XMTPContext);
-  const { processors, namespaces } = xmtpContext;
+  const { processors, namespaces, validators } = xmtpContext;
   const { client } = useClient();
   const { db } = useDb();
 
@@ -44,11 +44,12 @@ export const useMessage = () => {
           message,
           namespaces,
           processors,
+          validators,
         });
       }
       return message;
     },
-    [client, db, namespaces, processors],
+    [client, db, namespaces, processors, validators],
   );
 
   const updateMessage = useCallback<RemoveLastParameter<typeof _updateMessage>>(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7591,6 +7591,7 @@ __metadata:
     vite: ^4.4.9
     vite-tsconfig-paths: ^4.2.0
     vitest: ^0.34.2
+    zod: ^3.22.1
   peerDependencies:
     "@xmtp/xmtp-js": ^10.1.0
     react: ">=16.14"
@@ -19010,6 +19011,13 @@ __metadata:
   version: 1.0.0
   resolution: "yocto-queue@npm:1.0.0"
   checksum: 2cac84540f65c64ccc1683c267edce396b26b1e931aa429660aefac8fbe0188167b7aee815a3c22fa59a28a58d898d1a2b1825048f834d8d629f4c2a5d443801
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.22.1":
+  version: 3.22.1
+  resolution: "zod@npm:3.22.1"
+  checksum: 05b62cc1069da6e6349ad2325ec6b7d0c00699f0796e0fd071bcc2b44ac711679e52ad00bc563019504c7e64bbf0bf73737f31366d882a856962cd6e2882cf0e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds content validators for all supported content types.

### Why content validators?

While the code behind a content type enforces the shape of its data, it does not prevent a bad actor from using malformed data with any content type. These content validators ensure that the messages being consumed are in the proper format based on its content type. This prevents potential exceptions from occurring when the wrong data format is used with a content type.

### What happens when message content is invalid?

The message is simply ignored. Whether it's an actual bad actor or just a developer accidentally sending the wrong message content, messages with invalid data cannot be properly processed and displayed to a user.