### PR TITLE
Greatly improve performance by removing mutexes

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -77,7 +77,6 @@
     "@xmtp/content-type-remote-attachment": "^1.0.7",
     "@xmtp/content-type-reply": "^1.0.0",
     "@xmtp/xmtp-js": "^10.2.0",
-    "async-mutex": "^0.4.0",
     "date-fns": "^2.30.0",
     "dexie": "^3.2.4",
     "dexie-react-hooks": "^1.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7572,7 +7572,6 @@ __metadata:
     "@xmtp/content-type-reply": ^1.0.0
     "@xmtp/tsconfig": "workspace:*"
     "@xmtp/xmtp-js": ^10.2.0
-    async-mutex: ^0.4.0
     date-fns: ^2.30.0
     dexie: ^3.2.4
     dexie-react-hooks: ^1.1.6


### PR DESCRIPTION
The use of a mutex when processing messages leads to a bad UX as all messages must be processed sequentially. This creates large delays as some messages require loading remote URLs.

Mutexes were originally introduced as a way to guarantee messages are processed in the right order, but after extensive testing, no conflicts have surfaced.