### PR TITLE
Rename `cacheConfig` to `contentTypeConfigs`

### DIFF
--- a/examples/react-quickstart/src/main.tsx
+++ b/examples/react-quickstart/src/main.tsx
@@ -8,10 +8,10 @@ import { mainnet } from "wagmi/chains";
 import { publicProvider } from "wagmi/providers/public";
 import {
   XMTPProvider,
-  attachmentsCacheConfig,
-  reactionsCacheConfig,
-  readReceiptsCacheConfig,
-  repliesCacheConfig,
+  attachmentContentTypeConfig,
+  reactionContentTypeConfig,
+  readReceiptContentTypeConfig,
+  replyContentTypeConfig,
 } from "@xmtp/react-sdk";
 import App from "./components/App";
 import "@xmtp/react-components/styles.css";
@@ -20,11 +20,11 @@ import "./index.css";
 
 const DB_VERSION = 1;
 
-const cacheConfig = [
-  attachmentsCacheConfig,
-  reactionsCacheConfig,
-  readReceiptsCacheConfig,
-  repliesCacheConfig,
+const contentTypeConfigs = [
+  attachmentContentTypeConfig,
+  reactionContentTypeConfig,
+  readReceiptContentTypeConfig,
+  replyContentTypeConfig,
 ];
 
 const { chains, provider, webSocketProvider } = configureChains(
@@ -51,7 +51,9 @@ createRoot(document.getElementById("root") as HTMLElement).render(
     <RainbowKitProvider chains={chains}>
       <StrictMode>
         <WalletProvider>
-          <XMTPProvider dbVersion={DB_VERSION} cacheConfig={cacheConfig}>
+          <XMTPProvider
+            dbVersion={DB_VERSION}
+            contentTypeConfigs={contentTypeConfigs}>
             <App />
           </XMTPProvider>
         </WalletProvider>

--- a/packages/react-sdk/src/contexts/XMTPContext.test.tsx
+++ b/packages/react-sdk/src/contexts/XMTPContext.test.tsx
@@ -5,14 +5,14 @@ import type { XMTPProviderProps } from "@/contexts/XMTPContext";
 import { XMTPProvider } from "@/contexts/XMTPContext";
 
 type TestWrapperProps = PropsWithChildren &
-  Pick<XMTPProviderProps, "dbVersion" | "cacheConfig">;
+  Pick<XMTPProviderProps, "dbVersion" | "contentTypeConfigs">;
 
 const TestWrapper: React.FC<TestWrapperProps> = ({
-  cacheConfig,
+  contentTypeConfigs,
   children,
   dbVersion,
 }) => (
-  <XMTPProvider cacheConfig={cacheConfig} dbVersion={dbVersion}>
+  <XMTPProvider contentTypeConfigs={contentTypeConfigs} dbVersion={dbVersion}>
     {children}
   </XMTPProvider>
 );

--- a/packages/react-sdk/src/helpers/caching/contentTypes/attachment.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/attachment.test.ts
@@ -16,7 +16,7 @@ import {
   hasAttachment,
   processAttachment,
   processRemoteAttachment,
-  attachmentsCacheConfig,
+  attachmentContentTypeConfig,
 } from "./attachment";
 import { type CachedMessageWithId } from "@/helpers/caching/messages";
 import { getDbInstance } from "@/helpers/caching/db";
@@ -24,22 +24,26 @@ import type { CachedConversationWithId } from "@/helpers/caching/conversations";
 
 const testWallet = Wallet.createRandom();
 const db = getDbInstance({
-  cacheConfig: [attachmentsCacheConfig],
+  contentTypeConfigs: [attachmentContentTypeConfig],
 });
 
 describe("ContentTypeRemoteAttachment caching", () => {
-  it("should have the correct cache config", () => {
-    expect(attachmentsCacheConfig.namespace).toEqual("attachment");
-    expect(attachmentsCacheConfig.codecs?.length).toEqual(2);
-    expect(attachmentsCacheConfig.codecs?.[0]).toBeInstanceOf(AttachmentCodec);
-    expect(attachmentsCacheConfig.codecs?.[1]).toBeInstanceOf(
+  it("should have the correct content types config", () => {
+    expect(attachmentContentTypeConfig.namespace).toEqual("attachment");
+    expect(attachmentContentTypeConfig.codecs?.length).toEqual(2);
+    expect(attachmentContentTypeConfig.codecs?.[0]).toBeInstanceOf(
+      AttachmentCodec,
+    );
+    expect(attachmentContentTypeConfig.codecs?.[1]).toBeInstanceOf(
       RemoteAttachmentCodec,
     );
     expect(
-      attachmentsCacheConfig.processors[ContentTypeAttachment.toString()],
+      attachmentContentTypeConfig.processors[ContentTypeAttachment.toString()],
     ).toEqual([processAttachment]);
     expect(
-      attachmentsCacheConfig.processors[ContentTypeRemoteAttachment.toString()],
+      attachmentContentTypeConfig.processors[
+        ContentTypeRemoteAttachment.toString()
+      ],
     ).toEqual([processRemoteAttachment]);
   });
 
@@ -83,7 +87,7 @@ describe("ContentTypeRemoteAttachment caching", () => {
         message: testMessage,
         persist,
         updateConversationMetadata,
-        processors: attachmentsCacheConfig.processors,
+        processors: attachmentContentTypeConfig.processors,
       });
       expect(persist).toHaveBeenCalledWith({
         metadata: testMessage.content,
@@ -125,7 +129,7 @@ describe("ContentTypeRemoteAttachment caching", () => {
         message: testMessage,
         persist,
         updateConversationMetadata,
-        processors: attachmentsCacheConfig.processors,
+        processors: attachmentContentTypeConfig.processors,
       });
       expect(persist).not.toHaveBeenCalled();
     });
@@ -184,7 +188,7 @@ describe("ContentTypeRemoteAttachment caching", () => {
         message: testMessage,
         persist,
         updateConversationMetadata,
-        processors: attachmentsCacheConfig.processors,
+        processors: attachmentContentTypeConfig.processors,
       });
       expect(spy).toHaveBeenCalledWith(testMessage.content, testClient);
       expect(persist).toHaveBeenCalledWith({
@@ -227,7 +231,7 @@ describe("ContentTypeRemoteAttachment caching", () => {
         message: testMessage,
         persist,
         updateConversationMetadata,
-        processors: attachmentsCacheConfig.processors,
+        processors: attachmentContentTypeConfig.processors,
       });
       expect(persist).not.toHaveBeenCalled();
     });
@@ -254,7 +258,7 @@ describe("ContentTypeRemoteAttachment caching", () => {
         uuid: "testUuid",
         xmtpID: "testXmtpId",
         metadata: {
-          [attachmentsCacheConfig.namespace]: testMetadata,
+          [attachmentContentTypeConfig.namespace]: testMetadata,
         },
       } satisfies CachedMessageWithId<Attachment>;
 
@@ -290,7 +294,7 @@ describe("ContentTypeRemoteAttachment caching", () => {
         uuid: "testUuid",
         xmtpID: "testXmtpId",
         metadata: {
-          [attachmentsCacheConfig.namespace]: testMetadata,
+          [attachmentContentTypeConfig.namespace]: testMetadata,
         },
       } satisfies CachedMessageWithId<Attachment>;
 

--- a/packages/react-sdk/src/helpers/caching/contentTypes/attachment.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/attachment.ts
@@ -10,7 +10,10 @@ import {
 } from "@xmtp/content-type-remote-attachment";
 import { ContentTypeId } from "@xmtp/xmtp-js";
 import { z } from "zod";
-import type { CacheConfiguration, CachedMessageProcessor } from "../db";
+import type {
+  ContentTypeConfiguration,
+  ContentTypeMessageProcessor,
+} from "../db";
 import { type CachedMessage } from "../messages";
 
 const NAMESPACE = "attachment";
@@ -59,7 +62,7 @@ const isValidAttachmentContent = (content: unknown) => {
  *
  * The message content is also saved to the metadata of the message.
  */
-export const processAttachment: CachedMessageProcessor = async ({
+export const processAttachment: ContentTypeMessageProcessor = async ({
   message,
   persist,
 }) => {
@@ -103,7 +106,7 @@ const isValidRemoveAttachmentContent = (content: unknown) => {
  * Loads the attachment from the remote URL and saves it to the metadata
  * of the message.
  */
-export const processRemoteAttachment: CachedMessageProcessor = async ({
+export const processRemoteAttachment: ContentTypeMessageProcessor = async ({
   client,
   message,
   persist,
@@ -125,7 +128,7 @@ export const processRemoteAttachment: CachedMessageProcessor = async ({
   }
 };
 
-export const attachmentsCacheConfig: CacheConfiguration = {
+export const attachmentContentTypeConfig: ContentTypeConfiguration = {
   codecs: [new AttachmentCodec(), new RemoteAttachmentCodec()],
   namespace: NAMESPACE,
   processors: {

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reaction.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reaction.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@xmtp/content-type-reaction";
 import type { CachedReaction, CachedReactionsTable } from "./reaction";
 import {
-  reactionsCacheConfig,
+  reactionContentTypeConfig,
   processReaction,
   getReactionsByXmtpID,
   hasReaction,
@@ -24,7 +24,7 @@ import type { CachedConversationWithId } from "@/helpers/caching/conversations";
 
 const testWallet = Wallet.createRandom();
 const db = getDbInstance({
-  cacheConfig: [reactionsCacheConfig],
+  contentTypeConfigs: [reactionContentTypeConfig],
 });
 
 describe("ContentTypeReaction caching", () => {
@@ -32,12 +32,12 @@ describe("ContentTypeReaction caching", () => {
     await clearCache(db);
   });
 
-  it("should have the correct cache config", () => {
-    expect(reactionsCacheConfig.namespace).toEqual("reactions");
-    expect(reactionsCacheConfig.codecs?.length).toEqual(1);
-    expect(reactionsCacheConfig.codecs?.[0]).toBeInstanceOf(ReactionCodec);
+  it("should have the correct content types config", () => {
+    expect(reactionContentTypeConfig.namespace).toEqual("reactions");
+    expect(reactionContentTypeConfig.codecs?.length).toEqual(1);
+    expect(reactionContentTypeConfig.codecs?.[0]).toBeInstanceOf(ReactionCodec);
     expect(
-      reactionsCacheConfig.processors[ContentTypeReaction.toString()],
+      reactionContentTypeConfig.processors[ContentTypeReaction.toString()],
     ).toEqual([processReaction]);
   });
 
@@ -127,7 +127,7 @@ describe("ContentTypeReaction caching", () => {
         message: testReactionMessage,
         persist,
         updateConversationMetadata,
-        processors: reactionsCacheConfig.processors,
+        processors: reactionContentTypeConfig.processors,
       });
       expect(persist).not.toHaveBeenCalled();
 
@@ -169,7 +169,7 @@ describe("ContentTypeReaction caching", () => {
         message: testReactionMessage2,
         persist,
         updateConversationMetadata,
-        processors: reactionsCacheConfig.processors,
+        processors: reactionContentTypeConfig.processors,
       });
       expect(persist).not.toHaveBeenCalled();
 
@@ -215,7 +215,7 @@ describe("ContentTypeReaction caching", () => {
         message: testMessage,
         persist,
         updateConversationMetadata,
-        processors: reactionsCacheConfig.processors,
+        processors: reactionContentTypeConfig.processors,
       });
       expect(persist).not.toHaveBeenCalled();
       const reactionsTable = db.table("reactions") as CachedReactionsTable;

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reaction.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reaction.ts
@@ -6,7 +6,10 @@ import {
 import { ContentTypeId } from "@xmtp/xmtp-js";
 import type { Dexie, Table } from "dexie";
 import { z } from "zod";
-import type { CacheConfiguration, CachedMessageProcessor } from "../db";
+import type {
+  ContentTypeConfiguration,
+  ContentTypeMessageProcessor,
+} from "../db";
 import type { CachedMessage } from "../messages";
 import { getMessageByXmtpID, updateMessageMetadata } from "../messages";
 
@@ -160,7 +163,7 @@ const isValidReactionContent = (content: unknown) => {
  * Adds or removes the reaction from the cache based on the `action`
  * property. The original message is not saved to the messages cache.
  */
-export const processReaction: CachedMessageProcessor = async ({
+export const processReaction: ContentTypeMessageProcessor = async ({
   message,
   db,
 }) => {
@@ -193,7 +196,7 @@ export const processReaction: CachedMessageProcessor = async ({
   }
 };
 
-export const reactionsCacheConfig: CacheConfiguration = {
+export const reactionContentTypeConfig: ContentTypeConfiguration = {
   codecs: [new ReactionCodec()],
   namespace: NAMESPACE,
   processors: {

--- a/packages/react-sdk/src/helpers/caching/contentTypes/readReceipt.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/readReceipt.test.ts
@@ -16,12 +16,12 @@ import {
   getReadReceipt,
   hasReadReceipt,
   processReadReceipt,
-  readReceiptsCacheConfig,
+  readReceiptContentTypeConfig,
 } from "@/helpers/caching/contentTypes/readReceipt";
 
 const testWallet = Wallet.createRandom();
 const db = getDbInstance({
-  cacheConfig: [readReceiptsCacheConfig],
+  contentTypeConfigs: [readReceiptContentTypeConfig],
 });
 
 describe("ContentTypeReadReceipt caching", () => {
@@ -29,14 +29,16 @@ describe("ContentTypeReadReceipt caching", () => {
     await clearCache(db);
   });
 
-  it("should have the correct cache config", () => {
-    expect(readReceiptsCacheConfig.namespace).toEqual("readReceipt");
-    expect(readReceiptsCacheConfig.codecs?.length).toEqual(1);
-    expect(readReceiptsCacheConfig.codecs?.[0]).toBeInstanceOf(
+  it("should have the correct content types config", () => {
+    expect(readReceiptContentTypeConfig.namespace).toEqual("readReceipt");
+    expect(readReceiptContentTypeConfig.codecs?.length).toEqual(1);
+    expect(readReceiptContentTypeConfig.codecs?.[0]).toBeInstanceOf(
       ReadReceiptCodec,
     );
     expect(
-      readReceiptsCacheConfig.processors[ContentTypeReadReceipt.toString()],
+      readReceiptContentTypeConfig.processors[
+        ContentTypeReadReceipt.toString()
+      ],
     ).toEqual([processReadReceipt]);
   });
 
@@ -85,7 +87,7 @@ describe("ContentTypeReadReceipt caching", () => {
         message: testReadReceiptMessage,
         persist,
         updateConversationMetadata,
-        processors: readReceiptsCacheConfig.processors,
+        processors: readReceiptContentTypeConfig.processors,
       });
       expect(persist).not.toHaveBeenCalled();
       expect(updateConversationMetadata).toHaveBeenCalledWith(
@@ -128,7 +130,7 @@ describe("ContentTypeReadReceipt caching", () => {
         message: testTextMessage,
         persist,
         updateConversationMetadata,
-        processors: readReceiptsCacheConfig.processors,
+        processors: readReceiptContentTypeConfig.processors,
       });
       expect(persist).not.toHaveBeenCalled();
       expect(updateConversationMetadata).not.toHaveBeenCalled();

--- a/packages/react-sdk/src/helpers/caching/contentTypes/readReceipt.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/readReceipt.ts
@@ -6,7 +6,10 @@ import {
 import { ContentTypeId } from "@xmtp/xmtp-js";
 import { parseISO } from "date-fns";
 import { z } from "zod";
-import type { CacheConfiguration, CachedMessageProcessor } from "../db";
+import type {
+  ContentTypeConfiguration,
+  ContentTypeMessageProcessor,
+} from "../db";
 import type { CachedConversation } from "../conversations";
 
 const NAMESPACE = "readReceipt";
@@ -57,7 +60,7 @@ const isValidReadReceiptContent = (content: unknown) => {
  * Updates the metadata of its conversation with the timestamp of the
  * read receipt.
  */
-export const processReadReceipt: CachedMessageProcessor = async ({
+export const processReadReceipt: ContentTypeMessageProcessor = async ({
   message,
   conversation,
   updateConversationMetadata,
@@ -75,7 +78,7 @@ export const processReadReceipt: CachedMessageProcessor = async ({
   }
 };
 
-export const readReceiptsCacheConfig: CacheConfiguration = {
+export const readReceiptContentTypeConfig: ContentTypeConfiguration = {
   codecs: [new ReadReceiptCodec()],
   namespace: NAMESPACE,
   processors: {

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reply.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reply.test.ts
@@ -6,7 +6,7 @@ import { ContentTypeReply, ReplyCodec } from "@xmtp/content-type-reply";
 import {
   processReply,
   hasReply,
-  repliesCacheConfig,
+  replyContentTypeConfig,
   getReplies,
   getOriginalMessageFromReply,
   addReply,
@@ -21,7 +21,7 @@ import type { CachedConversationWithId } from "@/helpers/caching/conversations";
 
 const testWallet = Wallet.createRandom();
 const db = getDbInstance({
-  cacheConfig: [repliesCacheConfig],
+  contentTypeConfigs: [replyContentTypeConfig],
 });
 
 describe("ContentTypeReply caching", () => {
@@ -29,13 +29,13 @@ describe("ContentTypeReply caching", () => {
     await clearCache(db);
   });
 
-  it("should have the correct cache config", () => {
-    expect(repliesCacheConfig.namespace).toEqual("replies");
-    expect(repliesCacheConfig.codecs?.length).toEqual(1);
-    expect(repliesCacheConfig.codecs?.[0]).toBeInstanceOf(ReplyCodec);
-    expect(repliesCacheConfig.processors[ContentTypeReply.toString()]).toEqual([
-      processReply,
-    ]);
+  it("should have the correct content types config", () => {
+    expect(replyContentTypeConfig.namespace).toEqual("replies");
+    expect(replyContentTypeConfig.codecs?.length).toEqual(1);
+    expect(replyContentTypeConfig.codecs?.[0]).toBeInstanceOf(ReplyCodec);
+    expect(
+      replyContentTypeConfig.processors[ContentTypeReply.toString()],
+    ).toEqual([processReply]);
   });
 
   describe("processReply", () => {
@@ -97,7 +97,7 @@ describe("ContentTypeReply caching", () => {
         message: testReplyMessage,
         persist,
         updateConversationMetadata,
-        processors: repliesCacheConfig.processors,
+        processors: replyContentTypeConfig.processors,
       });
       expect(persist).toHaveBeenCalledWith();
       // since we mocked persist, we need to manually save the message
@@ -152,7 +152,7 @@ describe("ContentTypeReply caching", () => {
         message: testMessage,
         persist,
         updateConversationMetadata,
-        processors: repliesCacheConfig.processors,
+        processors: replyContentTypeConfig.processors,
       });
       expect(persist).not.toHaveBeenCalled();
     });

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reply.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reply.ts
@@ -4,7 +4,10 @@ import { ContentTypeId } from "@xmtp/xmtp-js";
 import type { Dexie } from "dexie";
 import { z } from "zod";
 import type { CachedMessage } from "@/helpers/caching/messages";
-import type { CacheConfiguration, CachedMessageProcessor } from "../db";
+import type {
+  ContentTypeConfiguration,
+  ContentTypeMessageProcessor,
+} from "../db";
 import { getMessageByXmtpID, updateMessageMetadata } from "../messages";
 
 const NAMESPACE = "replies";
@@ -108,7 +111,7 @@ const isValidReplyContent = (content: unknown) => {
  * Saves the reply message to the cache and updates the metadata of the
  * original message with the new reply.
  */
-export const processReply: CachedMessageProcessor = async ({
+export const processReply: ContentTypeMessageProcessor = async ({
   message,
   db,
   persist,
@@ -128,7 +131,7 @@ export const processReply: CachedMessageProcessor = async ({
   }
 };
 
-export const repliesCacheConfig: CacheConfiguration = {
+export const replyContentTypeConfig: ContentTypeConfiguration = {
   codecs: [new ReplyCodec()],
   namespace: NAMESPACE,
   processors: {

--- a/packages/react-sdk/src/helpers/caching/contentTypes/text.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/text.test.ts
@@ -19,7 +19,7 @@ const db = getDbInstance();
 describe("ContentTypeText caching", () => {
   it("should have the correct content types config", () => {
     expect(textContentTypeConfig.namespace).toEqual("text");
-    expect(textContentTypeConfig.codecs).toBeUndefined();
+    expect(textContentTypeConfig.codecs).toEqual([]);
     expect(
       textContentTypeConfig.processors[ContentTypeText.toString()],
     ).toEqual([processText]);

--- a/packages/react-sdk/src/helpers/caching/contentTypes/text.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/text.test.ts
@@ -10,19 +10,19 @@ import { getDbInstance } from "@/helpers/caching/db";
 import type { CachedConversationWithId } from "@/helpers/caching/conversations";
 import {
   processText,
-  textCacheConfig,
+  textContentTypeConfig,
 } from "@/helpers/caching/contentTypes/text";
 
 const testWallet = Wallet.createRandom();
 const db = getDbInstance();
 
 describe("ContentTypeText caching", () => {
-  it("should have the correct cache config", () => {
-    expect(textCacheConfig.namespace).toEqual("text");
-    expect(textCacheConfig.codecs).toBeUndefined();
-    expect(textCacheConfig.processors[ContentTypeText.toString()]).toEqual([
-      processText,
-    ]);
+  it("should have the correct content types config", () => {
+    expect(textContentTypeConfig.namespace).toEqual("text");
+    expect(textContentTypeConfig.codecs).toBeUndefined();
+    expect(
+      textContentTypeConfig.processors[ContentTypeText.toString()],
+    ).toEqual([processText]);
   });
 
   describe("processText", () => {
@@ -61,7 +61,7 @@ describe("ContentTypeText caching", () => {
         message: testMessage,
         persist,
         updateConversationMetadata,
-        processors: textCacheConfig.processors,
+        processors: textContentTypeConfig.processors,
       });
       expect(persist).toHaveBeenCalledWith();
     });
@@ -105,7 +105,7 @@ describe("ContentTypeText caching", () => {
         message: testMessage,
         persist,
         updateConversationMetadata,
-        processors: textCacheConfig.processors,
+        processors: textContentTypeConfig.processors,
       });
       expect(persist).not.toHaveBeenCalled();
     });

--- a/packages/react-sdk/src/helpers/caching/contentTypes/text.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/text.ts
@@ -35,6 +35,8 @@ export const processText: ContentTypeMessageProcessor = async ({
 
 export const textContentTypeConfig: ContentTypeConfiguration = {
   namespace: NAMESPACE,
+  // the text codec is registered automatically in the JS SDK
+  codecs: [],
   processors: {
     [ContentTypeText.toString()]: [processText],
   },

--- a/packages/react-sdk/src/helpers/caching/contentTypes/text.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/text.ts
@@ -1,5 +1,8 @@
 import { ContentTypeId, ContentTypeText } from "@xmtp/xmtp-js";
-import type { CacheConfiguration, CachedMessageProcessor } from "../db";
+import type {
+  ContentTypeConfiguration,
+  ContentTypeMessageProcessor,
+} from "../db";
 
 const NAMESPACE = "text";
 
@@ -16,7 +19,7 @@ const isValidTextContent = (content: unknown) => typeof content === "string";
  *
  * Saves the message to the cache.
  */
-export const processText: CachedMessageProcessor = async ({
+export const processText: ContentTypeMessageProcessor = async ({
   message,
   persist,
 }) => {
@@ -30,7 +33,7 @@ export const processText: CachedMessageProcessor = async ({
   }
 };
 
-export const textCacheConfig: CacheConfiguration = {
+export const textContentTypeConfig: ContentTypeConfiguration = {
   namespace: NAMESPACE,
   processors: {
     [ContentTypeText.toString()]: [processText],

--- a/packages/react-sdk/src/helpers/caching/conversations.ts
+++ b/packages/react-sdk/src/helpers/caching/conversations.ts
@@ -1,9 +1,9 @@
 import type { Conversation, Client, InvitationContext } from "@xmtp/xmtp-js";
 import type { Table } from "dexie";
 import type Dexie from "dexie";
-import type { CachedMetadata, CachedMetadataValues } from "./db";
+import type { ContentTypeMetadata, ContentTypeMetadataValues } from "./db";
 
-export type CachedConversation<M = CachedMetadata> = {
+export type CachedConversation<M = ContentTypeMetadata> = {
   context?: InvitationContext;
   createdAt: Date;
   id?: number;
@@ -122,7 +122,7 @@ export const updateConversation = async (
 export const updateConversationMetadata = async (
   topic: string,
   namespace: string,
-  data: CachedMetadataValues,
+  data: ContentTypeMetadataValues,
   db: Dexie,
 ) => {
   const existing = await getCachedConversationByTopic(topic, db);

--- a/packages/react-sdk/src/helpers/caching/db.ts
+++ b/packages/react-sdk/src/helpers/caching/db.ts
@@ -5,9 +5,9 @@ import type {
   CachedMessageWithId,
 } from "@/helpers/caching/messages";
 import type { CachedConversation } from "./conversations";
-import { textCacheConfig } from "./contentTypes/text";
+import { textContentTypeConfig } from "./contentTypes/text";
 
-export type CachedMetadataValue =
+export type ContentTypeMetadataValue =
   | string
   | string[]
   | number
@@ -17,53 +17,55 @@ export type CachedMetadataValue =
   | null
   | Uint8Array;
 
-export type CachedMetadataValues =
-  | CachedMetadataValue
-  | Record<string, CachedMetadataValue>;
+export type ContentTypeMetadataValues =
+  | ContentTypeMetadataValue
+  | Record<string, ContentTypeMetadataValue>;
 
-export type CachedMetadata = {
-  [namespace: string]: CachedMetadataValues;
+export type ContentTypeMetadata = {
+  [namespace: string]: ContentTypeMetadataValues;
 };
 
 export type InternalPersistMessageOptions = {
   update?: Partial<Omit<CachedMessage, "id" | "metadata">>;
-  metadata?: CachedMetadataValues;
+  metadata?: ContentTypeMetadataValues;
 };
 
 export type InternalPersistMessage = (
   options?: InternalPersistMessageOptions,
 ) => Promise<CachedMessageWithId<any>>;
 
-export type CachedMessageProcessor<C = any> = (options: {
+export type ContentTypeMessageProcessor<C = any> = (options: {
   client: Client;
   conversation: CachedConversation;
   db: Dexie;
   message: CachedMessageWithId<C>;
-  processors: CachedMessageProcessors;
+  processors: ContentTypeMessageProcessors;
   persist: InternalPersistMessage;
-  updateConversationMetadata: (data: CachedMetadataValues) => Promise<void>;
+  updateConversationMetadata: (
+    data: ContentTypeMetadataValues,
+  ) => Promise<void>;
 }) => Promise<void>;
 
-export type CachedMessageValidators = Record<
+export type ContentTypeMessageValidators = Record<
   string,
   (content: unknown) => boolean
 >;
 
-export type CacheConfiguration = {
+export type ContentTypeConfiguration = {
   codecs?: ContentCodec<any>[];
   namespace: string;
-  processors: CachedMessageProcessors;
+  processors: ContentTypeMessageProcessors;
   schema?: Record<string, string>;
-  validators?: CachedMessageValidators;
+  validators?: ContentTypeMessageValidators;
 };
 
-export type CachedMessageProcessors = {
-  [contentType: string]: CachedMessageProcessor[];
+export type ContentTypeMessageProcessors = {
+  [contentType: string]: ContentTypeMessageProcessor[];
 };
 
 export type GetDBInstanceOptions = {
   db?: Dexie;
-  cacheConfig?: CacheConfiguration[];
+  contentTypeConfigs?: ContentTypeConfiguration[];
   version?: number;
 };
 
@@ -74,7 +76,7 @@ export const getDbInstance = (options?: GetDBInstanceOptions) => {
   const db = options?.db ?? new Dexie("__XMTP__");
 
   // note that duplicate keys will be overwritten
-  const customSchema = options?.cacheConfig?.reduce(
+  const customSchema = options?.contentTypeConfigs?.reduce(
     (result, { schema }) => ({
       ...result,
       ...schema,
@@ -119,4 +121,4 @@ export const clearCache = async (db: Dexie) => {
 };
 
 // handle text messages by default
-export const defaultCacheConfig = [textCacheConfig];
+export const defaultContentTypeConfigs = [textContentTypeConfig];

--- a/packages/react-sdk/src/helpers/caching/db.ts
+++ b/packages/react-sdk/src/helpers/caching/db.ts
@@ -52,7 +52,7 @@ export type ContentTypeMessageValidators = Record<
 >;
 
 export type ContentTypeConfiguration = {
-  codecs?: ContentCodec<any>[];
+  codecs: ContentCodec<any>[];
   namespace: string;
   processors: ContentTypeMessageProcessors;
   schema?: Record<string, string>;

--- a/packages/react-sdk/src/helpers/caching/messages.test.ts
+++ b/packages/react-sdk/src/helpers/caching/messages.test.ts
@@ -18,7 +18,7 @@ import {
   reprocessMessage,
   processUnprocessedMessages,
 } from "@/helpers/caching/messages";
-import type { CachedMessageProcessor } from "@/helpers/caching/db";
+import type { ContentTypeMessageProcessor } from "@/helpers/caching/db";
 import { getDbInstance, clearCache } from "@/helpers/caching/db";
 import {
   saveConversation,
@@ -26,7 +26,7 @@ import {
   getCachedConversationByTopic,
 } from "@/helpers/caching/conversations";
 import { adjustDate } from "@/helpers/adjustDate";
-import { textCacheConfig } from "@/helpers/caching/contentTypes/text";
+import { textContentTypeConfig } from "@/helpers/caching/contentTypes/text";
 
 const db = getDbInstance();
 const testWallet1 = Wallet.createRandom();
@@ -443,7 +443,7 @@ describe("getUnprocessedMessages", () => {
 
 describe("processMessage", () => {
   const mockProcessor1 = vi.fn<
-    ArgumentsType<CachedMessageProcessor>,
+    ArgumentsType<ContentTypeMessageProcessor>,
     Promise<void>
   >();
   const mockProcessor2 = vi.fn();
@@ -620,7 +620,7 @@ describe("processMessage", () => {
       message: testMessage,
       namespaces: testNamepaces,
       processors: testProcessors,
-      validators: textCacheConfig.validators ?? {},
+      validators: textContentTypeConfig.validators ?? {},
     });
     expect(cachedMessage).toEqual(testMessage);
     expect(mockProcessor1).not.toHaveBeenCalled();

--- a/packages/react-sdk/src/helpers/caching/messages.ts
+++ b/packages/react-sdk/src/helpers/caching/messages.ts
@@ -5,10 +5,10 @@ import type Dexie from "dexie";
 import { isAfter } from "date-fns";
 import { v4 } from "uuid";
 import type {
-  CachedMessageProcessors,
-  CachedMessageValidators,
-  CachedMetadata,
-  CachedMetadataValues,
+  ContentTypeMessageProcessors,
+  ContentTypeMessageValidators,
+  ContentTypeMetadata,
+  ContentTypeMetadataValues,
   InternalPersistMessage,
 } from "./db";
 import type { CachedConversation } from "./conversations";
@@ -18,7 +18,7 @@ import {
   updateConversationMetadata as _updateConversationMetadata,
 } from "./conversations";
 
-export type CachedMessage<C = any, M = CachedMetadata> = {
+export type CachedMessage<C = any, M = ContentTypeMetadata> = {
   content: C;
   contentBytes?: Uint8Array;
   contentFallback?: string;
@@ -165,7 +165,7 @@ export const updateMessage = async (
 export const updateMessageMetadata = async (
   message: CachedMessage,
   namespace: string,
-  data: CachedMetadataValues,
+  data: ContentTypeMetadataValues,
   db: Dexie,
 ) => {
   const metadata = message.metadata || {};
@@ -237,8 +237,8 @@ export type ProcessMessageOptions = {
   db: Dexie;
   message: CachedMessage;
   namespaces: Record<string, string>;
-  processors: CachedMessageProcessors;
-  validators: CachedMessageValidators;
+  processors: ContentTypeMessageProcessors;
+  validators: ContentTypeMessageValidators;
 };
 
 export type ReprocessMessageOptions = ProcessMessageOptions & {
@@ -305,7 +305,9 @@ export const processMessage = async (
   };
 
   // internal updater function with preset namespace
-  const updateConversationMetadata = async (data: CachedMetadataValues) => {
+  const updateConversationMetadata = async (
+    data: ContentTypeMetadataValues,
+  ) => {
     await _updateConversationMetadata(conversation.topic, namespace, data, db);
   };
 

--- a/packages/react-sdk/src/helpers/combineCodecs.test.ts
+++ b/packages/react-sdk/src/helpers/combineCodecs.test.ts
@@ -7,20 +7,20 @@ import { ReactionCodec } from "@xmtp/content-type-reaction";
 import { ReadReceiptCodec } from "@xmtp/content-type-read-receipt";
 import { ReplyCodec } from "@xmtp/content-type-reply";
 import { combineCodecs } from "@/helpers/combineCodecs";
-import { attachmentsCacheConfig } from "@/helpers/caching/contentTypes/attachment";
-import { reactionsCacheConfig } from "@/helpers/caching/contentTypes/reaction";
-import { readReceiptsCacheConfig } from "@/helpers/caching/contentTypes/readReceipt";
-import { repliesCacheConfig } from "@/helpers/caching/contentTypes/reply";
+import { attachmentContentTypeConfig } from "@/helpers/caching/contentTypes/attachment";
+import { reactionContentTypeConfig } from "@/helpers/caching/contentTypes/reaction";
+import { readReceiptContentTypeConfig } from "@/helpers/caching/contentTypes/readReceipt";
+import { replyContentTypeConfig } from "@/helpers/caching/contentTypes/reply";
 
 const testCacheConfig = [
-  attachmentsCacheConfig,
-  reactionsCacheConfig,
-  readReceiptsCacheConfig,
-  repliesCacheConfig,
+  attachmentContentTypeConfig,
+  reactionContentTypeConfig,
+  readReceiptContentTypeConfig,
+  replyContentTypeConfig,
 ];
 
 describe("combineCodecs", () => {
-  it("should combine codecs from a cache config", () => {
+  it("should combine codecs from a content types config", () => {
     expect(combineCodecs(testCacheConfig)).toEqual([
       new AttachmentCodec(),
       new RemoteAttachmentCodec(),
@@ -30,7 +30,7 @@ describe("combineCodecs", () => {
     ]);
   });
 
-  it("should have no codecs without a cache config", () => {
+  it("should have no codecs without a content types config", () => {
     expect(combineCodecs()).toEqual([]);
   });
 });

--- a/packages/react-sdk/src/helpers/combineCodecs.ts
+++ b/packages/react-sdk/src/helpers/combineCodecs.ts
@@ -1,17 +1,22 @@
 import type { ContentCodec } from "@xmtp/xmtp-js";
 import {
-  defaultCacheConfig,
-  type CacheConfiguration,
+  defaultContentTypeConfigs,
+  type ContentTypeConfiguration,
 } from "@/helpers/caching/db";
 
 /**
  * Formats all codecs into a simple array
  *
- * @param cacheConfig The cache configuration to extract the codecs from
+ * @param contentTypeConfigs The content types configuration to extract the codecs from
  * @returns An array of codecs
  */
-export const combineCodecs = (cacheConfig?: CacheConfiguration[]) => {
-  const finalCacheConfig = [...defaultCacheConfig, ...(cacheConfig ?? [])];
+export const combineCodecs = (
+  contentTypeConfigs?: ContentTypeConfiguration[],
+) => {
+  const finalCacheConfig = [
+    ...defaultContentTypeConfigs,
+    ...(contentTypeConfigs ?? []),
+  ];
   return finalCacheConfig.reduce(
     (result, config) => [...result, ...(config.codecs ?? [])],
     [] as ContentCodec<any>[],

--- a/packages/react-sdk/src/helpers/combineMessageProcessors.test.ts
+++ b/packages/react-sdk/src/helpers/combineMessageProcessors.test.ts
@@ -9,33 +9,33 @@ import { ContentTypeReply } from "@xmtp/content-type-reply";
 import { ContentTypeText } from "@xmtp/xmtp-js";
 import { combineMessageProcessors } from "@/helpers/combineMessageProcessors";
 import {
-  attachmentsCacheConfig,
+  attachmentContentTypeConfig,
   processAttachment,
   processRemoteAttachment,
 } from "@/helpers/caching/contentTypes/attachment";
 import {
   processReaction,
-  reactionsCacheConfig,
+  reactionContentTypeConfig,
 } from "@/helpers/caching/contentTypes/reaction";
 import {
   processReadReceipt,
-  readReceiptsCacheConfig,
+  readReceiptContentTypeConfig,
 } from "@/helpers/caching/contentTypes/readReceipt";
 import {
   processReply,
-  repliesCacheConfig,
+  replyContentTypeConfig,
 } from "@/helpers/caching/contentTypes/reply";
 import { processText } from "@/helpers/caching/contentTypes/text";
 
 const testCacheConfig = [
-  attachmentsCacheConfig,
-  reactionsCacheConfig,
-  readReceiptsCacheConfig,
-  repliesCacheConfig,
+  attachmentContentTypeConfig,
+  reactionContentTypeConfig,
+  readReceiptContentTypeConfig,
+  replyContentTypeConfig,
 ];
 
 describe("combineMessageProcessors", () => {
-  it("should combine message processors from a cache config", () => {
+  it("should combine message processors from a content types config", () => {
     expect(combineMessageProcessors(testCacheConfig)).toEqual({
       [ContentTypeAttachment.toString()]: [processAttachment],
       [ContentTypeRemoteAttachment.toString()]: [processRemoteAttachment],
@@ -46,7 +46,7 @@ describe("combineMessageProcessors", () => {
     });
   });
 
-  it("should only have text message processors without a cache config", () => {
+  it("should only have text message processors without a content types config", () => {
     expect(combineMessageProcessors()).toEqual({
       [ContentTypeText.toString()]: [processText],
     });

--- a/packages/react-sdk/src/helpers/combineMessageProcessors.ts
+++ b/packages/react-sdk/src/helpers/combineMessageProcessors.ts
@@ -1,19 +1,22 @@
-import { defaultCacheConfig } from "@/helpers/caching/db";
+import { defaultContentTypeConfigs } from "@/helpers/caching/db";
 import type {
-  CachedMessageProcessors,
-  CacheConfiguration,
+  ContentTypeMessageProcessors,
+  ContentTypeConfiguration,
 } from "@/helpers/caching/db";
 
 /**
  * Combines all message processors into a single object
  *
- * @param cacheConfig The cache configuration to extract the processors from
+ * @param contentTypeConfigs The content types configuration to extract the processors from
  * @returns An object that maps content types to their respective message processors
  */
 export const combineMessageProcessors = (
-  cacheConfig?: CacheConfiguration[],
+  contentTypeConfigs?: ContentTypeConfiguration[],
 ) => {
-  const finalCacheConfig = [...defaultCacheConfig, ...(cacheConfig ?? [])];
+  const finalCacheConfig = [
+    ...defaultContentTypeConfigs,
+    ...(contentTypeConfigs ?? []),
+  ];
   return {
     ...finalCacheConfig.reduce((result, config) => {
       const update = Object.entries(config.processors).reduce(
@@ -21,12 +24,12 @@ export const combineMessageProcessors = (
           ...updateResult,
           [contentType]: [...(result[contentType] ?? []), ...contentProcessors],
         }),
-        {} as CachedMessageProcessors,
+        {} as ContentTypeMessageProcessors,
       );
       return {
         ...result,
         ...update,
       };
-    }, {} as CachedMessageProcessors),
+    }, {} as ContentTypeMessageProcessors),
   };
 };

--- a/packages/react-sdk/src/helpers/combineNamespaces.test.ts
+++ b/packages/react-sdk/src/helpers/combineNamespaces.test.ts
@@ -43,6 +43,7 @@ describe("combineNamespaces", () => {
       combineNamespaces([
         {
           namespace: "text",
+          codecs: [],
           processors: {
             foo: [() => Promise.resolve()],
           },

--- a/packages/react-sdk/src/helpers/combineNamespaces.test.ts
+++ b/packages/react-sdk/src/helpers/combineNamespaces.test.ts
@@ -8,20 +8,20 @@ import { ContentTypeReadReceipt } from "@xmtp/content-type-read-receipt";
 import { ContentTypeReply } from "@xmtp/content-type-reply";
 import { ContentTypeText } from "@xmtp/xmtp-js";
 import { combineNamespaces } from "@/helpers/combineNamespaces";
-import { attachmentsCacheConfig } from "@/helpers/caching/contentTypes/attachment";
-import { reactionsCacheConfig } from "@/helpers/caching/contentTypes/reaction";
-import { readReceiptsCacheConfig } from "@/helpers/caching/contentTypes/readReceipt";
-import { repliesCacheConfig } from "@/helpers/caching/contentTypes/reply";
+import { attachmentContentTypeConfig } from "@/helpers/caching/contentTypes/attachment";
+import { reactionContentTypeConfig } from "@/helpers/caching/contentTypes/reaction";
+import { readReceiptContentTypeConfig } from "@/helpers/caching/contentTypes/readReceipt";
+import { replyContentTypeConfig } from "@/helpers/caching/contentTypes/reply";
 
 const testCacheConfig = [
-  attachmentsCacheConfig,
-  reactionsCacheConfig,
-  readReceiptsCacheConfig,
-  repliesCacheConfig,
+  attachmentContentTypeConfig,
+  reactionContentTypeConfig,
+  readReceiptContentTypeConfig,
+  replyContentTypeConfig,
 ];
 
 describe("combineNamespaces", () => {
-  it("should combine namespaces from a cache config", () => {
+  it("should combine namespaces from a content types config", () => {
     expect(combineNamespaces(testCacheConfig)).toEqual({
       [ContentTypeAttachment.toString()]: "attachment",
       [ContentTypeRemoteAttachment.toString()]: "attachment",
@@ -32,7 +32,7 @@ describe("combineNamespaces", () => {
     });
   });
 
-  it("should only have a text namespace without a cache config", () => {
+  it("should only have a text namespace without a content types config", () => {
     expect(combineNamespaces()).toEqual({
       [ContentTypeText.toString()]: "text",
     });
@@ -48,6 +48,6 @@ describe("combineNamespaces", () => {
           },
         },
       ]),
-    ).toThrow(`Duplicate cache config namespace detected: "text"`);
+    ).toThrow(`Duplicate content types config namespace detected: "text"`);
   });
 });

--- a/packages/react-sdk/src/helpers/combineNamespaces.ts
+++ b/packages/react-sdk/src/helpers/combineNamespaces.ts
@@ -1,17 +1,22 @@
 import {
-  defaultCacheConfig,
-  type CacheConfiguration,
+  defaultContentTypeConfigs,
+  type ContentTypeConfiguration,
 } from "@/helpers/caching/db";
 
 /**
  * Combines all namespaces into a single object
  *
- * @param cacheConfig The cache configuration to extract the namespaces from
+ * @param contentTypeConfigs The content types configuration to extract the namespaces from
  * @returns An object that maps content types to their respective namespace
  */
-export const combineNamespaces = (cacheConfig?: CacheConfiguration[]) => {
+export const combineNamespaces = (
+  contentTypeConfigs?: ContentTypeConfiguration[],
+) => {
   // merge default config with passed in config
-  const finalCacheConfig = [...defaultCacheConfig, ...(cacheConfig ?? [])];
+  const finalCacheConfig = [
+    ...defaultContentTypeConfigs,
+    ...(contentTypeConfigs ?? []),
+  ];
   // array of namespaces for detecting duplicates
   const namespaces: string[] = [];
   return finalCacheConfig.reduce(
@@ -19,7 +24,7 @@ export const combineNamespaces = (cacheConfig?: CacheConfiguration[]) => {
       // prevent duplicate namespaces
       if (namespaces.includes(config.namespace)) {
         throw new Error(
-          `Duplicate cache config namespace detected: "${config.namespace}"`,
+          `Duplicate content types config namespace detected: "${config.namespace}"`,
         );
       }
       namespaces.push(config.namespace);

--- a/packages/react-sdk/src/helpers/combineValidators.test.ts
+++ b/packages/react-sdk/src/helpers/combineValidators.test.ts
@@ -1,32 +1,32 @@
 import { it, expect, describe } from "vitest";
 import { ContentTypeText } from "@xmtp/xmtp-js";
 import { combineValidators } from "@/helpers/combineValidators";
-import { attachmentsCacheConfig } from "@/helpers/caching/contentTypes/attachment";
-import { reactionsCacheConfig } from "@/helpers/caching/contentTypes/reaction";
-import { readReceiptsCacheConfig } from "@/helpers/caching/contentTypes/readReceipt";
-import { repliesCacheConfig } from "@/helpers/caching/contentTypes/reply";
-import { textCacheConfig } from "@/helpers/caching/contentTypes/text";
+import { attachmentContentTypeConfig } from "@/helpers/caching/contentTypes/attachment";
+import { reactionContentTypeConfig } from "@/helpers/caching/contentTypes/reaction";
+import { readReceiptContentTypeConfig } from "@/helpers/caching/contentTypes/readReceipt";
+import { replyContentTypeConfig } from "@/helpers/caching/contentTypes/reply";
+import { textContentTypeConfig } from "@/helpers/caching/contentTypes/text";
 
 const testCacheConfig = [
-  attachmentsCacheConfig,
-  reactionsCacheConfig,
-  readReceiptsCacheConfig,
-  repliesCacheConfig,
+  attachmentContentTypeConfig,
+  reactionContentTypeConfig,
+  readReceiptContentTypeConfig,
+  replyContentTypeConfig,
 ];
 
 describe("combineValidators", () => {
-  it("should combine content validators from a cache config", () => {
+  it("should combine content validators from a content types config", () => {
     expect(combineValidators(testCacheConfig)).toEqual({
-      ...attachmentsCacheConfig.validators,
-      ...reactionsCacheConfig.validators,
-      ...readReceiptsCacheConfig.validators,
-      ...repliesCacheConfig.validators,
-      ...textCacheConfig.validators,
+      ...attachmentContentTypeConfig.validators,
+      ...reactionContentTypeConfig.validators,
+      ...readReceiptContentTypeConfig.validators,
+      ...replyContentTypeConfig.validators,
+      ...textContentTypeConfig.validators,
     });
   });
 
-  it("should only have a text content validator without a cache config", () => {
-    expect(combineValidators()).toEqual(textCacheConfig.validators);
+  it("should only have a text content validator without a content types config", () => {
+    expect(combineValidators()).toEqual(textContentTypeConfig.validators);
   });
 
   it("should throw when there's a duplicate content type validator", () => {

--- a/packages/react-sdk/src/helpers/combineValidators.test.ts
+++ b/packages/react-sdk/src/helpers/combineValidators.test.ts
@@ -34,6 +34,7 @@ describe("combineValidators", () => {
       combineValidators([
         {
           namespace: "foo",
+          codecs: [],
           processors: {},
           validators: {
             [ContentTypeText.toString()]: () => false,

--- a/packages/react-sdk/src/helpers/combineValidators.ts
+++ b/packages/react-sdk/src/helpers/combineValidators.ts
@@ -1,22 +1,27 @@
-import { defaultCacheConfig } from "@/helpers/caching/db";
+import { defaultContentTypeConfigs } from "@/helpers/caching/db";
 import type {
-  CachedMessageValidators,
-  CacheConfiguration,
+  ContentTypeMessageValidators,
+  ContentTypeConfiguration,
 } from "@/helpers/caching/db";
 
 /**
  * Combines all content validators into a single object
  *
- * @param cacheConfig The cache configuration to extract the content validators from
+ * @param contentTypeConfigs The content types configuration to extract the content validators from
  * @returns An object that maps content types to their respective content validator
  */
-export const combineValidators = (cacheConfig?: CacheConfiguration[]) => {
+export const combineValidators = (
+  contentTypeConfigs?: ContentTypeConfiguration[],
+) => {
   // merge default config with passed in config
-  const finalCacheConfig = [...defaultCacheConfig, ...(cacheConfig ?? [])];
+  const finalCacheConfig = [
+    ...defaultContentTypeConfigs,
+    ...(contentTypeConfigs ?? []),
+  ];
   // array of validator content types for detecting duplicates
   const validatorContentTypes: string[] = [];
   return finalCacheConfig.reduce((result, config) => {
-    const validators: CachedMessageValidators = {};
+    const validators: ContentTypeMessageValidators = {};
     // prevent duplicate content type validators
     Object.entries(config.validators ?? {}).forEach(
       ([contentType, validator]) => {
@@ -33,5 +38,5 @@ export const combineValidators = (cacheConfig?: CacheConfiguration[]) => {
       ...result,
       ...validators,
     };
-  }, {} as CachedMessageValidators);
+  }, {} as ContentTypeMessageValidators);
 };

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -55,7 +55,7 @@ export {
 // attachments
 export type { CachedAttachmentsMetadata } from "./helpers/caching/contentTypes/attachment";
 export {
-  attachmentsCacheConfig,
+  attachmentContentTypeConfig,
   getAttachment,
 } from "./helpers/caching/contentTypes/attachment";
 
@@ -68,13 +68,13 @@ export type {
 export {
   getReactionsByXmtpID,
   hasReaction,
-  reactionsCacheConfig,
+  reactionContentTypeConfig,
 } from "./helpers/caching/contentTypes/reaction";
 
 // read receipts
 export type { CachedReadReceiptMetadata } from "./helpers/caching/contentTypes/readReceipt";
 export {
-  readReceiptsCacheConfig,
+  readReceiptContentTypeConfig,
   hasReadReceipt,
   getReadReceipt,
 } from "./helpers/caching/contentTypes/readReceipt";
@@ -84,11 +84,11 @@ export type { CachedRepliesMetadata } from "./helpers/caching/contentTypes/reply
 export {
   hasReply,
   getOriginalMessageFromReply,
-  repliesCacheConfig,
+  replyContentTypeConfig,
 } from "./helpers/caching/contentTypes/reply";
 
 // text
-export { textCacheConfig } from "./helpers/caching/contentTypes/text";
+export { textContentTypeConfig } from "./helpers/caching/contentTypes/text";
 
 export {
   Client,


### PR DESCRIPTION
This PR just removes the `cache` terminology from a bunch of variables and replaces them with content type to better reflect their purpose.