### PR TITLE
Add `useResendMessage` hook, update exports

### DIFF
--- a/packages/react-sdk/src/hooks/useConversation.ts
+++ b/packages/react-sdk/src/hooks/useConversation.ts
@@ -14,11 +14,7 @@ import type { RemoveLastParameter } from "@/sharedTypes";
 import { useClient } from "@/hooks/useClient";
 import { useDb } from "@/hooks/useDb";
 
-/**
- * This hook returns helper functions for working with conversations in the
- * local cache.
- */
-export const useConversation = () => {
+export const useConversationInternal = () => {
   const { client } = useClient();
   const { db } = useDb();
 
@@ -45,6 +41,21 @@ export const useConversation = () => {
     },
     [db],
   );
+
+  return {
+    saveConversation,
+    updateConversation,
+    updateMetadata,
+  };
+};
+
+/**
+ * This hook returns helper functions for working with conversations in the
+ * local cache.
+ */
+export const useConversation = () => {
+  const { client } = useClient();
+  const { db } = useDb();
 
   const getByTopic = useCallback<
     RemoveLastParameter<typeof getConversationByTopic>
@@ -84,8 +95,5 @@ export const useConversation = () => {
     getCachedByPeerAddress,
     getLastMessage,
     hasTopic,
-    saveConversation,
-    updateConversation,
-    updateMetadata,
   };
 };

--- a/packages/react-sdk/src/hooks/useConversations.ts
+++ b/packages/react-sdk/src/hooks/useConversations.ts
@@ -4,7 +4,10 @@ import { useClient } from "./useClient";
 import type { OnError } from "../sharedTypes";
 import { useCachedConversations } from "./useCachedConversations";
 import { toCachedMessage } from "@/helpers/caching/messages";
-import { useConversation } from "@/hooks/useConversation";
+import {
+  useConversation,
+  useConversationInternal,
+} from "@/hooks/useConversation";
 import { useMessage } from "@/hooks/useMessage";
 import { toCachedConversation } from "@/helpers/caching/conversations";
 
@@ -24,7 +27,8 @@ export const useConversations = (options?: UseConversationsOptions) => {
   const [error, setError] = useState<Error | null>(null);
   const { client } = useClient();
   const { processMessage } = useMessage();
-  const { saveConversation, hasTopic } = useConversation();
+  const { saveConversation } = useConversationInternal();
+  const { hasTopic } = useConversation();
   const conversations = useCachedConversations();
   // to prevent conversations from being fetched multiple times
   const loadingRef = useRef(false);

--- a/packages/react-sdk/src/hooks/useMessage.test.ts
+++ b/packages/react-sdk/src/hooks/useMessage.test.ts
@@ -299,6 +299,35 @@ describe("useMessage", () => {
   });
 
   describe("resendMessage", () => {
+    it("should throw an error if the message never failed to send", async () => {
+      useClientMock.mockImplementation(() => ({
+        client: undefined,
+      }));
+
+      const { result } = renderHook(() => useMessage());
+
+      await act(async () => {
+        await expect(
+          result.current.resendMessage({
+            id: 1,
+            content: "test",
+            contentType: ContentTypeText.toString(),
+            hasSendError: false,
+            conversationTopic: "testTopic",
+            isSending: false,
+            senderAddress: testWalletAddress,
+            sentAt: new Date(),
+            status: "processed",
+            uuid: "testUuid",
+            walletAddress: testWalletAddress,
+            xmtpID: "testXmtpId",
+          } satisfies CachedMessage),
+        ).rejects.toThrow(
+          "Resending a message that hasn't failed to send is not allowed",
+        );
+      });
+    });
+
     it("should throw an error if no client is available", async () => {
       useClientMock.mockImplementation(() => ({
         client: undefined,

--- a/packages/react-sdk/src/hooks/useMessage.ts
+++ b/packages/react-sdk/src/hooks/useMessage.ts
@@ -9,7 +9,10 @@ import {
   prepareMessageForSending,
   getMessageByXmtpID as _getMessageByXmtpID,
 } from "@/helpers/caching/messages";
-import type { CachedMessage } from "@/helpers/caching/messages";
+import type {
+  CachedMessage,
+  CachedMessageWithId,
+} from "@/helpers/caching/messages";
 import { getConversationByTopic } from "@/helpers/caching/conversations";
 import type { CachedConversation } from "@/helpers/caching/conversations";
 import type { RemoveLastParameter } from "@/sharedTypes";
@@ -164,7 +167,13 @@ export const useMessage = () => {
    * @returns The sent message, or `undefined` if there's no XMTP client
    */
   const resendMessage = useCallback(
-    async (message: CachedMessage) => {
+    async (message: CachedMessageWithId) => {
+      if (!message.hasSendError) {
+        throw new Error(
+          "Resending a message that hasn't failed to send is not allowed",
+        );
+      }
+
       if (!client) {
         throw new Error("XMTP client is required to send a message");
       }

--- a/packages/react-sdk/src/hooks/useMessages.ts
+++ b/packages/react-sdk/src/hooks/useMessages.ts
@@ -7,7 +7,7 @@ import { adjustDate } from "@/helpers/adjustDate";
 import { getConversationByTopic } from "@/helpers/caching/conversations";
 import type { CachedConversation } from "@/helpers/caching/conversations";
 import { useClient } from "./useClient";
-import { useConversation } from "@/hooks/useConversation";
+import { useConversationInternal } from "@/hooks/useConversation";
 import { useMessage } from "@/hooks/useMessage";
 
 export type UseMessagesOptions = OnError & {
@@ -29,7 +29,7 @@ export const useMessages = (
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const { processMessage } = useMessage();
-  const { updateConversation } = useConversation();
+  const { updateConversation } = useConversationInternal();
   const messages = useCachedMessages(conversation.topic);
   const { client } = useClient();
   // to prevent messages from being fetched multiple times

--- a/packages/react-sdk/src/hooks/useResendMessage.test.ts
+++ b/packages/react-sdk/src/hooks/useResendMessage.test.ts
@@ -1,0 +1,102 @@
+import { it, expect, describe, vi, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { ContentTypeText } from "@xmtp/xmtp-js";
+import { useResendMessage } from "@/hooks/useResendMessage";
+import type { CachedMessageWithId } from "@/helpers/caching/messages";
+
+const resendMessageMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/useMessage", async () => {
+  const actual = await import("@/hooks/useMessage");
+  return {
+    useMessage: () => ({
+      ...actual.useMessage,
+      resendMessage: resendMessageMock,
+    }),
+  };
+});
+
+describe("useResendMessage", () => {
+  beforeEach(() => {
+    resendMessageMock.mockReset();
+  });
+
+  it("should resend a previously failed message", async () => {
+    resendMessageMock.mockResolvedValueOnce({ id: 1 });
+    const onSuccessMock = vi.fn();
+
+    const testMessage = {
+      id: 1,
+      content: "test",
+      contentType: ContentTypeText.toString(),
+      hasSendError: true,
+      conversationTopic: "testTopic",
+      isSending: false,
+      senderAddress: "testSenderAddress",
+      sentAt: new Date(),
+      status: "processed",
+      uuid: "testUuid",
+      walletAddress: "testWalletAddress",
+      xmtpID: "testXmtpId",
+    } satisfies CachedMessageWithId;
+
+    const { result } = renderHook(() =>
+      useResendMessage({
+        onSuccess: onSuccessMock,
+      }),
+    );
+
+    await act(async () => {
+      const sentMessage = await result.current.resendMessage(testMessage);
+      expect(sentMessage).toEqual({ id: 1 });
+      expect(onSuccessMock).toHaveBeenCalledTimes(1);
+      expect(onSuccessMock).toHaveBeenCalledWith(sentMessage);
+    });
+
+    expect(resendMessageMock).toHaveBeenCalledTimes(1);
+    expect(resendMessageMock).toHaveBeenCalledWith(testMessage);
+  });
+
+  it("should have an error when resending fails", async () => {
+    const testError = new Error("testError");
+    resendMessageMock.mockRejectedValueOnce(testError);
+    const onErrorMock = vi.fn();
+
+    const testMessage = {
+      id: 1,
+      content: "test",
+      contentType: ContentTypeText.toString(),
+      hasSendError: true,
+      conversationTopic: "testTopic",
+      isSending: false,
+      senderAddress: "testSenderAddress",
+      sentAt: new Date(),
+      status: "processed",
+      uuid: "testUuid",
+      walletAddress: "testWalletAddress",
+      xmtpID: "testXmtpId",
+    } satisfies CachedMessageWithId;
+
+    const { result } = renderHook(() =>
+      useResendMessage({
+        onError: onErrorMock,
+      }),
+    );
+
+    await act(async () => {
+      try {
+        await result.current.resendMessage(testMessage);
+      } catch (e) {
+        expect(e).toEqual(testError);
+      } finally {
+        expect(resendMessageMock).toHaveBeenCalledTimes(1);
+        expect(onErrorMock).toHaveBeenCalledTimes(1);
+        expect(onErrorMock).toHaveBeenCalledWith(testError);
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toEqual(testError);
+    });
+  });
+});

--- a/packages/react-sdk/src/hooks/useResendMessage.ts
+++ b/packages/react-sdk/src/hooks/useResendMessage.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from "react";
+import { useMessage } from "@/hooks/useMessage";
+import type { UseSendMessageOptions } from "@/hooks/useSendMessage";
+import type { CachedMessageWithId } from "@/helpers/caching/messages";
+
+/**
+ * This hook resends a cached message that previously failed to send.
+ */
+export const useResendMessage = (options?: UseSendMessageOptions) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const { resendMessage: _resendMessage } = useMessage();
+
+  // destructure options for more granular dependency array
+  const { onError, onSuccess } = options ?? {};
+
+  const resendMessage = useCallback(
+    async (message: CachedMessageWithId) => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const sentMessage = await _resendMessage(message);
+        onSuccess?.(sentMessage);
+        return sentMessage;
+      } catch (e) {
+        setError(e as Error);
+        onError?.(e as Error);
+        // re-throw error for upstream consumption
+        throw e;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [_resendMessage, onError, onSuccess],
+  );
+
+  return {
+    error,
+    isLoading,
+    resendMessage,
+  };
+};

--- a/packages/react-sdk/src/hooks/useStartConversation.test.ts
+++ b/packages/react-sdk/src/hooks/useStartConversation.test.ts
@@ -30,8 +30,9 @@ vi.mock("@/hooks/useMessage", async () => {
 vi.mock("@/hooks/useConversation", async () => {
   const actual = await import("@/hooks/useConversation");
   return {
-    useConversation: () => ({
-      ...actual.useConversation,
+    ...actual,
+    useConversationInternal: () => ({
+      ...actual.useConversationInternal,
       saveConversation: saveConversationMock,
     }),
   };

--- a/packages/react-sdk/src/hooks/useStartConversation.ts
+++ b/packages/react-sdk/src/hooks/useStartConversation.ts
@@ -3,7 +3,7 @@ import type { ContentTypeId, InvitationContext } from "@xmtp/xmtp-js";
 import { useClient } from "./useClient";
 import type { OnError } from "../sharedTypes";
 import type { SendMessageOptions } from "@/hooks/useMessage";
-import { useConversation } from "@/hooks/useConversation";
+import { useConversationInternal } from "@/hooks/useConversation";
 import { useMessage } from "@/hooks/useMessage";
 import { toCachedConversation } from "@/helpers/caching/conversations";
 
@@ -17,7 +17,7 @@ export const useStartConversation = (options?: UseStartConversation) => {
   const [error, setError] = useState<Error | null>(null);
   const { client } = useClient();
   const { sendMessage: _sendMessage } = useMessage();
-  const { saveConversation } = useConversation();
+  const { saveConversation } = useConversationInternal();
 
   // destructure options for more granular dependency arrays
   const { conversationId, metadata, onError } = options ?? {};

--- a/packages/react-sdk/src/hooks/useStreamConversations.ts
+++ b/packages/react-sdk/src/hooks/useStreamConversations.ts
@@ -2,7 +2,7 @@ import type { Conversation, Stream } from "@xmtp/xmtp-js";
 import { useEffect, useRef, useState } from "react";
 import { useClient } from "./useClient";
 import type { OnError } from "../sharedTypes";
-import { useConversation } from "@/hooks/useConversation";
+import { useConversationInternal } from "@/hooks/useConversation";
 import { toCachedConversation } from "@/helpers/caching/conversations";
 
 export type ConversationStream = Promise<Stream<Conversation>>;
@@ -33,7 +33,7 @@ export const useStreamConversations = (
   });
 
   const { client } = useClient();
-  const { saveConversation } = useConversation();
+  const { saveConversation } = useConversationInternal();
 
   // destructure options for more granular dependency array
   const { onConversation, onError } = options ?? {};

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -18,8 +18,8 @@ export { useStreamConversations } from "./hooks/useStreamConversations";
 export { useLastMessage } from "./hooks/useLastMessage";
 export { useCanMessage } from "./hooks/useCanMessage";
 export { useMessages } from "./hooks/useMessages";
-export { useMessage } from "./hooks/useMessage";
 export { useSendMessage } from "./hooks/useSendMessage";
+export { useResendMessage } from "./hooks/useResendMessage";
 export { useStreamAllMessages } from "./hooks/useStreamAllMessages";
 export { useStreamMessages } from "./hooks/useStreamMessages";
 


### PR DESCRIPTION
This PR adds a new hook for resending messages and removes exports of internal functions for managing cached conversations and messages.