### PR TITLE
Refactor processing of attachment content types

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,5 +12,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@xmtp/react-quickstart-example", "@xmtp/react-components"]
 }

--- a/.changeset/gentle-snails-shave.md
+++ b/.changeset/gentle-snails-shave.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-sdk": minor
+---
+
+Refactor processing of remote attachment content types. This update removes eager loading of remote data in the message processor in favor of the new `useAttachment` hook. With the `useAttachment` hook, developers can now respond to loading and error states when fetching the remote data.

--- a/packages/react-components/src/components/AttachmentContent.tsx
+++ b/packages/react-components/src/components/AttachmentContent.tsx
@@ -1,6 +1,6 @@
 import type { Attachment } from "@xmtp/content-type-remote-attachment";
 import type { CachedMessage } from "@xmtp/react-sdk";
-import { useAttachment, useClient } from "@xmtp/react-sdk";
+import { useAttachment } from "@xmtp/react-sdk";
 import styles from "./Attachment.module.css";
 
 export type AttachmentProps = {
@@ -30,8 +30,7 @@ const getBlobURL = (attachment: Attachment) => {
 };
 
 export const AttachmentContent: React.FC<AttachmentProps> = ({ message }) => {
-  const { client } = useClient();
-  const { attachment, isLoading, error } = useAttachment(message, client);
+  const { attachment, isLoading, error } = useAttachment(message);
 
   if (error) {
     return "Unable to load attachment";

--- a/packages/react-components/src/components/AttachmentContent.tsx
+++ b/packages/react-components/src/components/AttachmentContent.tsx
@@ -1,8 +1,10 @@
 import type { Attachment } from "@xmtp/content-type-remote-attachment";
+import type { CachedMessage } from "@xmtp/react-sdk";
+import { useAttachment, useClient } from "@xmtp/react-sdk";
 import styles from "./Attachment.module.css";
 
 export type AttachmentProps = {
-  attachment?: Attachment;
+  message: CachedMessage;
 };
 
 /**
@@ -27,10 +29,15 @@ const getBlobURL = (attachment: Attachment) => {
   return blobCache.get(attachment.data)!;
 };
 
-export const AttachmentContent: React.FC<AttachmentProps> = ({
-  attachment,
-}) => {
-  if (!attachment) {
+export const AttachmentContent: React.FC<AttachmentProps> = ({ message }) => {
+  const { client } = useClient();
+  const { attachment, isLoading, error } = useAttachment(message, client);
+
+  if (error) {
+    return "Unable to load attachment";
+  }
+
+  if (isLoading || !attachment) {
     return "Loading...";
   }
 

--- a/packages/react-components/src/components/MessageContent.tsx
+++ b/packages/react-components/src/components/MessageContent.tsx
@@ -1,4 +1,4 @@
-import { ContentTypeId, ContentTypeText, getAttachment } from "@xmtp/react-sdk";
+import { ContentTypeId, ContentTypeText } from "@xmtp/react-sdk";
 import type { CachedMessage } from "@xmtp/react-sdk";
 import {
   ContentTypeAttachment,
@@ -33,7 +33,7 @@ export const MessageContent: React.FC<MessageContentProps> = ({
     contentType.sameAs(ContentTypeAttachment) ||
     contentType.sameAs(ContentTypeRemoteAttachment)
   ) {
-    content = <AttachmentContent attachment={getAttachment(message)} />;
+    content = <AttachmentContent message={message} />;
   }
 
   return (

--- a/packages/react-sdk/src/hooks/useAttachment.ts
+++ b/packages/react-sdk/src/hooks/useAttachment.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  ContentTypeAttachment,
+  ContentTypeRemoteAttachment,
+  RemoteAttachmentCodec,
+} from "@xmtp/content-type-remote-attachment";
+import type {
+  RemoteAttachment,
+  Attachment,
+} from "@xmtp/content-type-remote-attachment";
+import type { Client } from "@xmtp/xmtp-js";
+import { useDb } from "./useDb";
+import type { CachedMessage } from "@/helpers/caching/messages";
+
+/**
+ * This hook returns the attachment data of a cached message
+ */
+export const useAttachment = (message: CachedMessage, client?: Client) => {
+  const { db } = useDb();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | undefined>(undefined);
+  const [attachment, setAttachment] = useState<Attachment | undefined>(
+    undefined,
+  );
+
+  const loadRemoteAttachment = useCallback(async () => {
+    if (client) {
+      try {
+        setIsLoading(true);
+        const loadedAttachment = await RemoteAttachmentCodec.load<Attachment>(
+          message.content as RemoteAttachment,
+          client,
+        );
+        setIsLoading(false);
+        setAttachment(loadedAttachment);
+      } catch (e) {
+        setError(new Error("Unable to load remote attachment"));
+      }
+    } else {
+      setError(new Error("XMTP client is required to load remote attachments"));
+    }
+  }, [client, message.content]);
+
+  useEffect(() => {
+    const getAttachment = async () => {
+      switch (message.contentType) {
+        case ContentTypeAttachment.toString(): {
+          setAttachment(message.content as Attachment);
+          break;
+        }
+        case ContentTypeRemoteAttachment.toString(): {
+          await loadRemoteAttachment();
+          break;
+        }
+        default:
+          setError(new Error("Message is not an attachment content type"));
+      }
+    };
+    void getAttachment();
+  }, [db, loadRemoteAttachment, message]);
+
+  return {
+    attachment,
+    error,
+    isLoading,
+    retry: loadRemoteAttachment,
+  };
+};

--- a/packages/react-sdk/src/hooks/useAttachment.ts
+++ b/packages/react-sdk/src/hooks/useAttachment.ts
@@ -8,14 +8,15 @@ import type {
   RemoteAttachment,
   Attachment,
 } from "@xmtp/content-type-remote-attachment";
-import type { Client } from "@xmtp/xmtp-js";
 import { useDb } from "./useDb";
 import type { CachedMessage } from "@/helpers/caching/messages";
+import { useClient } from "@/hooks/useClient";
 
 /**
  * This hook returns the attachment data of a cached message
  */
-export const useAttachment = (message: CachedMessage, client?: Client) => {
+export const useAttachment = (message: CachedMessage) => {
+  const { client } = useClient();
   const { db } = useDb();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | undefined>(undefined);

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -53,7 +53,6 @@ export {
 } from "./helpers/caching/messages";
 
 // attachments
-export type { CachedAttachmentsMetadata } from "./helpers/caching/contentTypes/attachment";
 export {
   attachmentContentTypeConfig,
   getAttachment,

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -23,6 +23,9 @@ export { useResendMessage } from "./hooks/useResendMessage";
 export { useStreamAllMessages } from "./hooks/useStreamAllMessages";
 export { useStreamMessages } from "./hooks/useStreamMessages";
 
+// attachments
+export { useAttachment } from "./hooks/useAttachment";
+
 // reactions
 export { useReactions } from "./hooks/useReactions";
 


### PR DESCRIPTION
This PR updates the remote attachment message processor, removing the loading of the attachment. It doesn't make much sense to eagerly fetch this data until the message is being rendered. In addition, it's much harder to respond to errors when loading fails in the message processor.

To that end, this PR also adds a `useAttachment` hook that can be used to load remote data when rendering a message with `ContentTypeRemoteAttachment`. With this new hook, developers can now monitor loading state and respond to errors when loading the data.