### PR TITLE
Fix streaming hooks

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -77,6 +77,7 @@
     "@xmtp/content-type-remote-attachment": "^1.0.7",
     "@xmtp/content-type-reply": "^1.0.0",
     "@xmtp/xmtp-js": "^10.2.0",
+    "async-mutex": "^0.4.0",
     "date-fns": "^2.30.0",
     "dexie": "^3.2.4",
     "dexie-react-hooks": "^1.1.6",

--- a/packages/react-sdk/src/hooks/useStreamAllMessages.ts
+++ b/packages/react-sdk/src/hooks/useStreamAllMessages.ts
@@ -41,6 +41,11 @@ export const useStreamAllMessages = (
     const endStream = endStreamRef.current;
 
     const streamAllMessages = async () => {
+      // don't start a stream if there's already one active
+      if (streamRef.current) {
+        return;
+      }
+
       // we can't do anything without a client
       if (client === undefined) {
         const clientError = new Error("XMTP client is not available");
@@ -50,12 +55,12 @@ export const useStreamAllMessages = (
         return;
       }
 
-      // don't start a stream if there's already one active
-      if (streamRef.current) {
-        return;
-      }
-
       try {
+        // check if stream exists again just in case this hook unmounted
+        // while this function was executing
+        if (streamRef.current) {
+          return;
+        }
         // it's important not to await the stream here so that we can cleanup
         // consistently if this hook unmounts during this call
         streamRef.current = client.conversations.streamAllMessages();

--- a/packages/react-sdk/src/hooks/useStreamConversations.ts
+++ b/packages/react-sdk/src/hooks/useStreamConversations.ts
@@ -47,6 +47,11 @@ export const useStreamConversations = (
     const endStream = endStreamRef.current;
 
     const streamConversations = async () => {
+      // don't start a stream if there's already one active
+      if (streamRef.current) {
+        return;
+      }
+
       // we can't do anything without a client
       if (client === undefined) {
         const clientError = new Error("XMTP client is not available");
@@ -56,12 +61,12 @@ export const useStreamConversations = (
         return;
       }
 
-      // don't start a stream if there's already one active
-      if (streamRef.current) {
-        return;
-      }
-
       try {
+        // check if stream exists again just in case this hook unmounted
+        // while this function was executing
+        if (streamRef.current) {
+          return;
+        }
         // it's important not to await the stream here so that we can cleanup
         // consistently if this hook unmounts during this call
         streamRef.current = client.conversations.stream();

--- a/packages/react-sdk/src/hooks/useStreamMessages.ts
+++ b/packages/react-sdk/src/hooks/useStreamMessages.ts
@@ -75,13 +75,17 @@ export const useStreamMessages = (
       }
 
       try {
+        // check if stream exists again just in case this hook unmounted
+        // while this function was executing
+        if (streamRef.current) {
+          return;
+        }
         // it's important not to await the stream here so that we can cleanup
         // consistently if this hook unmounts during this call
         streamRef.current = networkConversation.streamMessages();
         stream = streamRef.current;
 
         for await (const message of await stream) {
-          // TODO: figure out why this is happening twice per send
           await processMessage(
             conversation,
             toCachedMessage(message, client.address),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7572,6 +7572,7 @@ __metadata:
     "@xmtp/content-type-reply": ^1.0.0
     "@xmtp/tsconfig": "workspace:*"
     "@xmtp/xmtp-js": ^10.2.0
+    async-mutex: ^0.4.0
     date-fns: ^2.30.0
     dexie: ^3.2.4
     dexie-react-hooks: ^1.1.6


### PR DESCRIPTION
The streaming hooks were creating 2 separate streams on a double mount (strict mode). This update adds another check to ensure duplicate streams aren't created in this scenario.

This PR also adds 2 additional checks to prevent potential duplicates of conversations and messages.