### PR TITLE
Fix useAttachment, reset loading state on error

### DIFF
--- a/.changeset/kind-melons-fail.md
+++ b/.changeset/kind-melons-fail.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-sdk": patch
+---
+
+Fix `useAttachment` hook by resetting loading state when an error occurs during the loading of a remote attachment

--- a/packages/react-sdk/src/hooks/useAttachment.ts
+++ b/packages/react-sdk/src/hooks/useAttachment.ts
@@ -53,10 +53,11 @@ export const useAttachment = (message: CachedMessage) => {
           // if this call fails, it's not a big deal
           // on the next render, the attachment data will be fetched again
         }
-        setIsLoading(false);
         setAttachment(loadedAttachment);
       } catch (e) {
         setError(new Error("Unable to load remote attachment"));
+      } finally {
+        setIsLoading(false);
       }
     } else {
       setError(new Error("XMTP client is required to load remote attachments"));


### PR DESCRIPTION
The loading state was not being reset when a remote attachment failed to load.