### PR TITLE
Add `cancel` function to `useResendMessage` hook

### DIFF
--- a/.changeset/cool-ducks-march.md
+++ b/.changeset/cool-ducks-march.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-sdk": patch
+---
+
+Add `cancel` function to `useResendMessage` hook, rename `resendMessage` to `resend`.

--- a/.changeset/cool-ducks-march.md
+++ b/.changeset/cool-ducks-march.md
@@ -1,5 +1,5 @@
 ---
-"@xmtp/react-sdk": patch
+"@xmtp/react-sdk": minor
 ---
 
 Add `cancel` function to `useResendMessage` hook, rename `resendMessage` to `resend`.

--- a/packages/react-sdk/src/hooks/useMessage.ts
+++ b/packages/react-sdk/src/hooks/useMessage.ts
@@ -8,6 +8,7 @@ import {
   updateMessageAfterSending as _updateMessageAfterSending,
   prepareMessageForSending,
   getMessageByXmtpID as _getMessageByXmtpID,
+  deleteMessage as _deleteMessage,
 } from "@/helpers/caching/messages";
 import type {
   CachedMessage,
@@ -73,6 +74,11 @@ export const useMessage = () => {
   const getMessageByXmtpID = useCallback<
     RemoveLastParameter<typeof _getMessageByXmtpID>
   >(async (xmtpID) => _getMessageByXmtpID(xmtpID, db), [db]);
+
+  const deleteMessage = useCallback<RemoveLastParameter<typeof _deleteMessage>>(
+    async (message) => _deleteMessage(message, db),
+    [db],
+  );
 
   /**
    * Send a message to a conversation on the XMTP network
@@ -210,6 +216,7 @@ export const useMessage = () => {
   );
 
   return {
+    deleteMessage,
     getMessageByXmtpID,
     processMessage,
     resendMessage,

--- a/packages/react-sdk/src/hooks/useResendMessage.test.ts
+++ b/packages/react-sdk/src/hooks/useResendMessage.test.ts
@@ -4,25 +4,25 @@ import { ContentTypeText } from "@xmtp/xmtp-js";
 import { useResendMessage } from "@/hooks/useResendMessage";
 import type { CachedMessageWithId } from "@/helpers/caching/messages";
 
-const resendMessageMock = vi.hoisted(() => vi.fn());
+const resendMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/hooks/useMessage", async () => {
   const actual = await import("@/hooks/useMessage");
   return {
     useMessage: () => ({
       ...actual.useMessage,
-      resendMessage: resendMessageMock,
+      resendMessage: resendMock,
     }),
   };
 });
 
 describe("useResendMessage", () => {
   beforeEach(() => {
-    resendMessageMock.mockReset();
+    resendMock.mockReset();
   });
 
   it("should resend a previously failed message", async () => {
-    resendMessageMock.mockResolvedValueOnce({ id: 1 });
+    resendMock.mockResolvedValueOnce({ id: 1 });
     const onSuccessMock = vi.fn();
 
     const testMessage = {
@@ -47,19 +47,19 @@ describe("useResendMessage", () => {
     );
 
     await act(async () => {
-      const sentMessage = await result.current.resendMessage(testMessage);
+      const sentMessage = await result.current.resend(testMessage);
       expect(sentMessage).toEqual({ id: 1 });
       expect(onSuccessMock).toHaveBeenCalledTimes(1);
       expect(onSuccessMock).toHaveBeenCalledWith(sentMessage);
     });
 
-    expect(resendMessageMock).toHaveBeenCalledTimes(1);
-    expect(resendMessageMock).toHaveBeenCalledWith(testMessage);
+    expect(resendMock).toHaveBeenCalledTimes(1);
+    expect(resendMock).toHaveBeenCalledWith(testMessage);
   });
 
   it("should have an error when resending fails", async () => {
     const testError = new Error("testError");
-    resendMessageMock.mockRejectedValueOnce(testError);
+    resendMock.mockRejectedValueOnce(testError);
     const onErrorMock = vi.fn();
 
     const testMessage = {
@@ -85,11 +85,11 @@ describe("useResendMessage", () => {
 
     await act(async () => {
       try {
-        await result.current.resendMessage(testMessage);
+        await result.current.resend(testMessage);
       } catch (e) {
         expect(e).toEqual(testError);
       } finally {
-        expect(resendMessageMock).toHaveBeenCalledTimes(1);
+        expect(resendMock).toHaveBeenCalledTimes(1);
         expect(onErrorMock).toHaveBeenCalledTimes(1);
         expect(onErrorMock).toHaveBeenCalledWith(testError);
       }


### PR DESCRIPTION
When a message fails to send, there are 2 options: resend the message, or cancel sending and remove it. This PR adds the cancel functionality to the `useResendMessage` hook so that developers can cancel the sending of failed messages.

It also renames the `resendMessage` function to simply `resend`.