### PR TITLE
Fix `useClient` and `useAttachment` performance

### DIFF
--- a/.changeset/slow-waves-chew.md
+++ b/.changeset/slow-waves-chew.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-sdk": patch
+---
+
+Fix `useClient` and `useAttachment` performance

--- a/packages/react-sdk/src/helpers/caching/contentTypes/attachment.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/attachment.ts
@@ -61,7 +61,7 @@ export const updateAttachmentData = async (
  * @returns The attachment data, or `undefined` if the message is not an
  * attachment content type
  */
-export const getAttachmentData = (message: CachedMessage) => {
+export const getRemoteAttachmentData = (message: CachedMessage) => {
   if (message.contentType === ContentTypeRemoteAttachment.toString()) {
     const metadata = message.metadata?.[NAMESPACE] as Attachment | undefined;
     return metadata;

--- a/packages/react-sdk/src/hooks/useClient.test.tsx
+++ b/packages/react-sdk/src/hooks/useClient.test.tsx
@@ -71,7 +71,7 @@ describe("useClient", () => {
     expect(clientCreateSpy).not.toHaveBeenCalled();
 
     await waitFor(() => {
-      expect(processUnprocessedMessagesMock).toBeCalledTimes(1);
+      expect(processUnprocessedMessagesMock).not.toHaveBeenCalled();
     });
   });
 
@@ -136,11 +136,7 @@ describe("useClient", () => {
     processUnprocessedMessagesMock.mockRejectedValue(testError);
 
     const { result } = renderHook(() => useClient(onErrorMock), {
-      wrapper: ({ children }) => (
-        <TestWrapper client={mockClient as unknown as Client}>
-          {children}
-        </TestWrapper>
-      ),
+      wrapper: ({ children }) => <TestWrapper>{children}</TestWrapper>,
     });
 
     await act(async () => {

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -51,7 +51,6 @@ export type {
 } from "./helpers/caching/messages";
 export {
   getMessageByXmtpID,
-  processUnprocessedMessages,
   toCachedMessage,
 } from "./helpers/caching/messages";
 


### PR DESCRIPTION
The `useClient` hook was causing performance issues due to its `useEffect` running when it should not. This PR moves the logic of that `useEffect` into the `initialize` function, where it should've lived all along.

The `useAttachment` hook was updated to prevent unnecessary loading of remote attachment data.