### PR TITLE
Make content type processors optional, add exports

### DIFF
--- a/.changeset/tasty-icons-brush.md
+++ b/.changeset/tasty-icons-brush.md
@@ -1,0 +1,6 @@
+---
+"@xmtp/react-sdk": patch
+---
+
+- Make content type config processors optional
+- Add type exports for content type configs

--- a/packages/react-sdk/src/helpers/caching/contentTypes/attachment.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/attachment.test.ts
@@ -38,10 +38,12 @@ describe("ContentTypeRemoteAttachment caching", () => {
       RemoteAttachmentCodec,
     );
     expect(
-      attachmentContentTypeConfig.processors[ContentTypeAttachment.toString()],
+      attachmentContentTypeConfig.processors?.[
+        ContentTypeAttachment.toString()
+      ],
     ).toEqual([processAttachment]);
     expect(
-      attachmentContentTypeConfig.processors[
+      attachmentContentTypeConfig.processors?.[
         ContentTypeRemoteAttachment.toString()
       ],
     ).toEqual([processRemoteAttachment]);

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reaction.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reaction.test.ts
@@ -37,7 +37,7 @@ describe("ContentTypeReaction caching", () => {
     expect(reactionContentTypeConfig.codecs?.length).toEqual(1);
     expect(reactionContentTypeConfig.codecs?.[0]).toBeInstanceOf(ReactionCodec);
     expect(
-      reactionContentTypeConfig.processors[ContentTypeReaction.toString()],
+      reactionContentTypeConfig.processors?.[ContentTypeReaction.toString()],
     ).toEqual([processReaction]);
   });
 

--- a/packages/react-sdk/src/helpers/caching/contentTypes/readReceipt.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/readReceipt.test.ts
@@ -36,7 +36,7 @@ describe("ContentTypeReadReceipt caching", () => {
       ReadReceiptCodec,
     );
     expect(
-      readReceiptContentTypeConfig.processors[
+      readReceiptContentTypeConfig.processors?.[
         ContentTypeReadReceipt.toString()
       ],
     ).toEqual([processReadReceipt]);

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reply.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reply.test.ts
@@ -34,7 +34,7 @@ describe("ContentTypeReply caching", () => {
     expect(replyContentTypeConfig.codecs?.length).toEqual(1);
     expect(replyContentTypeConfig.codecs?.[0]).toBeInstanceOf(ReplyCodec);
     expect(
-      replyContentTypeConfig.processors[ContentTypeReply.toString()],
+      replyContentTypeConfig.processors?.[ContentTypeReply.toString()],
     ).toEqual([processReply]);
   });
 

--- a/packages/react-sdk/src/helpers/caching/contentTypes/text.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/text.test.ts
@@ -21,7 +21,7 @@ describe("ContentTypeText caching", () => {
     expect(textContentTypeConfig.namespace).toEqual("text");
     expect(textContentTypeConfig.codecs).toEqual([]);
     expect(
-      textContentTypeConfig.processors[ContentTypeText.toString()],
+      textContentTypeConfig.processors?.[ContentTypeText.toString()],
     ).toEqual([processText]);
   });
 

--- a/packages/react-sdk/src/helpers/caching/db.ts
+++ b/packages/react-sdk/src/helpers/caching/db.ts
@@ -39,7 +39,7 @@ export type ContentTypeMessageProcessor<C = any> = (options: {
   conversation: CachedConversation;
   db: Dexie;
   message: CachedMessageWithId<C>;
-  processors: ContentTypeMessageProcessors;
+  processors?: ContentTypeMessageProcessors;
   persist: InternalPersistMessage;
   updateConversationMetadata: (
     data: ContentTypeMetadataValues,
@@ -54,7 +54,7 @@ export type ContentTypeMessageValidators = Record<
 export type ContentTypeConfiguration = {
   codecs: ContentCodec<any>[];
   namespace: string;
-  processors: ContentTypeMessageProcessors;
+  processors?: ContentTypeMessageProcessors;
   schema?: Record<string, string>;
   validators?: ContentTypeMessageValidators;
 };

--- a/packages/react-sdk/src/helpers/combineMessageProcessors.ts
+++ b/packages/react-sdk/src/helpers/combineMessageProcessors.ts
@@ -19,7 +19,7 @@ export const combineMessageProcessors = (
   ];
   return {
     ...finalCacheConfig.reduce((result, config) => {
-      const update = Object.entries(config.processors).reduce(
+      const update = Object.entries(config.processors ?? []).reduce(
         (updateResult, [contentType, contentProcessors]) => ({
           ...updateResult,
           [contentType]: [...(result[contentType] ?? []), ...contentProcessors],

--- a/packages/react-sdk/src/helpers/combineNamespaces.ts
+++ b/packages/react-sdk/src/helpers/combineNamespaces.ts
@@ -29,7 +29,7 @@ export const combineNamespaces = (
       }
       namespaces.push(config.namespace);
       // assign namespaces to content types
-      const names = Object.entries(config.processors).reduce(
+      const names = Object.entries(config.processors ?? []).reduce(
         (namespacesResult, [contentType]) => ({
           ...namespacesResult,
           [contentType]: config.namespace,

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -35,6 +35,16 @@ export { useReply } from "./hooks/useReply";
 // caching
 export { getDbInstance } from "./helpers/caching/db";
 
+export type {
+  ContentTypeMetadataValue,
+  ContentTypeConfiguration,
+  ContentTypeMessageProcessor,
+  ContentTypeMessageProcessors,
+  ContentTypeMessageValidators,
+  ContentTypeMetadata,
+  ContentTypeMetadataValues,
+} from "./helpers/caching/db";
+
 // conversations
 export type {
   CachedConversation,


### PR DESCRIPTION
This PR removes the need for content processors in content type configs. It also adds several type exports that are necessary for external content type configs.