### PR TITLE
Prevent DB versioning when DB is already open

### DIFF
--- a/.changeset/friendly-coins-confess.md
+++ b/.changeset/friendly-coins-confess.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-sdk": patch
+---
+
+- Prevent DB versioning when DB is already open

--- a/packages/react-sdk/src/helpers/caching/db.ts
+++ b/packages/react-sdk/src/helpers/caching/db.ts
@@ -75,42 +75,45 @@ export type GetDBInstanceOptions = {
 export const getDbInstance = (options?: GetDBInstanceOptions) => {
   const db = options?.db ?? new Dexie("__XMTP__");
 
-  // note that duplicate keys will be overwritten
-  const customSchema = options?.contentTypeConfigs?.reduce(
-    (result, { schema }) => ({
-      ...result,
-      ...schema,
-    }),
-    {} as Record<string, string>,
-  );
+  // do not attempt to version the db if it is already open
+  if (!db.isOpen()) {
+    // note that duplicate keys will be overwritten
+    const customSchema = options?.contentTypeConfigs?.reduce(
+      (result, { schema }) => ({
+        ...result,
+        ...schema,
+      }),
+      {} as Record<string, string>,
+    );
 
-  const version = options?.version ?? 1;
+    const version = options?.version ?? 1;
 
-  db.version(version).stores({
-    ...customSchema,
-    conversations: `
-      ++id,
-      [topic+walletAddress],
-      createdAt,
-      peerAddress,
-      topic,
-      updatedAt,
-      walletAddress
-    `,
-    messages: `
-      ++id,
-      [conversationTopic+walletAddress],
-      contentFallback,
-      contentType,
-      conversationTopic,
-      senderAddress,
-      sentAt,
-      status,
-      uuid,
-      walletAddress,
-      xmtpID
-    `,
-  });
+    db.version(version).stores({
+      ...customSchema,
+      conversations: `
+        ++id,
+        [topic+walletAddress],
+        createdAt,
+        peerAddress,
+        topic,
+        updatedAt,
+        walletAddress
+      `,
+      messages: `
+        ++id,
+        [conversationTopic+walletAddress],
+        contentFallback,
+        contentType,
+        conversationTopic,
+        senderAddress,
+        sentAt,
+        status,
+        uuid,
+        walletAddress,
+        xmtpID
+      `,
+    });
+  }
 
   return db;
 };


### PR DESCRIPTION
When using multiple clients in an app, it's possible that the DB is already open in another client, which causes an exception to occur. This PR fixes the issue.