### PR TITLE
Update xmtp-js to version 11

### DIFF
--- a/.changeset/kind-moose-hang.md
+++ b/.changeset/kind-moose-hang.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-sdk": minor
+---
+
+Update xmtp-js to version 11

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,12 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@xmtp/react-quickstart-example": "0.0.0",
+    "eslint-config-xmtp-web": "1.0.0",
+    "@xmtp/react-components": "1.0.0-preview.0",
+    "@xmtp/react-sdk": "1.3.4",
+    "@xmtp/tsconfig": "0.0.0"
+  },
+  "changesets": []
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - beta
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@changesets/cli": "^2.26.2"
   },
   "resolutions": {
-    "@xmtp/xmtp-js": "^10.2.0",
+    "@xmtp/xmtp-js": "^11.0.0-beta.8",
     "vite": "^4.4.9"
   }
 }

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -76,7 +76,7 @@
     "@xmtp/content-type-read-receipt": "^1.0.1",
     "@xmtp/content-type-remote-attachment": "^1.0.7",
     "@xmtp/content-type-reply": "^1.0.0",
-    "@xmtp/xmtp-js": "^10.2.1",
+    "@xmtp/xmtp-js": "^11.0.0-beta.8",
     "async-mutex": "^0.4.0",
     "date-fns": "^2.30.0",
     "dexie": "^3.2.4",
@@ -109,7 +109,7 @@
     "vitest": "^0.34.2"
   },
   "peerDependencies": {
-    "@xmtp/xmtp-js": "^10.2.1",
+    "@xmtp/xmtp-js": "^11.0.0-beta.8",
     "react": ">=16.14"
   },
   "engines": {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -72,10 +72,10 @@
     "typedoc": "typedoc"
   },
   "dependencies": {
-    "@xmtp/content-type-reaction": "^1.0.1",
-    "@xmtp/content-type-read-receipt": "^1.0.1",
-    "@xmtp/content-type-remote-attachment": "^1.0.7",
-    "@xmtp/content-type-reply": "^1.0.0",
+    "@xmtp/content-type-reaction": "^1.1.0",
+    "@xmtp/content-type-read-receipt": "^1.1.0",
+    "@xmtp/content-type-remote-attachment": "^1.1.0",
+    "@xmtp/content-type-reply": "^1.1.0",
     "@xmtp/xmtp-js": "^11.0.0-beta.8",
     "async-mutex": "^0.4.0",
     "date-fns": "^2.30.0",

--- a/packages/react-sdk/src/hooks/useSendMessage.test.ts
+++ b/packages/react-sdk/src/hooks/useSendMessage.test.ts
@@ -105,7 +105,6 @@ describe("useSendMessage", () => {
       testAttachment,
       ContentTypeAttachment,
       {
-        contentFallback: "test",
         onError: onErrorMock,
         onSuccess: onSuccessMock,
       },

--- a/packages/react-sdk/src/hooks/useSendMessage.test.ts
+++ b/packages/react-sdk/src/hooks/useSendMessage.test.ts
@@ -94,9 +94,7 @@ describe("useSendMessage", () => {
         testConversation,
         testAttachment,
         ContentTypeAttachment,
-        {
-          contentFallback: "test",
-        },
+        {},
       );
       expect(sentMessage).toEqual({ id: 1 });
     });

--- a/packages/react-sdk/src/hooks/useSendMessage.test.ts
+++ b/packages/react-sdk/src/hooks/useSendMessage.test.ts
@@ -94,7 +94,6 @@ describe("useSendMessage", () => {
         testConversation,
         testAttachment,
         ContentTypeAttachment,
-        {},
       );
       expect(sentMessage).toEqual({ id: 1 });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7458,18 +7458,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/proto@npm:^3.24.0":
-  version: 3.25.0
-  resolution: "@xmtp/proto@npm:3.25.0"
-  dependencies:
-    long: ^5.2.0
-    protobufjs: ^7.0.0
-    rxjs: ^7.8.0
-    undici: ^5.8.1
-  checksum: 9673abcbe5b53252d12216bd24743c1176e4c7578c0214333668009fa1ef98dd9a422c388122096d5a175fc886651b87107d35d7cb836e6d647c9923b290fd77
-  languageName: node
-  linkType: hard
-
 "@xmtp/proto@npm:^3.25.0, @xmtp/proto@npm:^3.26.0":
   version: 3.26.0
   resolution: "@xmtp/proto@npm:3.26.0"
@@ -7479,6 +7467,18 @@ __metadata:
     rxjs: ^7.8.0
     undici: ^5.8.1
   checksum: 2d29c5fdcaa3332577fac20a65a7ca837e937b8aab5c6bb2f20a198e5d07c9d76b534676fcc98b5375ef00f5f9f54f858d55524b3da40b8fe1db4225e1c4fdd7
+  languageName: node
+  linkType: hard
+
+"@xmtp/proto@npm:^3.28.0-beta.1":
+  version: 3.28.0-beta.1
+  resolution: "@xmtp/proto@npm:3.28.0-beta.1"
+  dependencies:
+    long: ^5.2.0
+    protobufjs: ^7.0.0
+    rxjs: ^7.8.0
+    undici: ^5.8.1
+  checksum: d222356318e72359bf54aea0fb967c3beeac94c82649c2e9c8cdb0a5a01ecf5c1264af1f1a4d2eeffb0d8b05561f0e3ee9b1ee44fa5742edfb0e1b288af8b96d
   languageName: node
   linkType: hard
 
@@ -7571,7 +7571,7 @@ __metadata:
     "@xmtp/content-type-remote-attachment": ^1.0.7
     "@xmtp/content-type-reply": ^1.0.0
     "@xmtp/tsconfig": "workspace:*"
-    "@xmtp/xmtp-js": ^10.2.1
+    "@xmtp/xmtp-js": ^11.0.0-beta.8
     async-mutex: ^0.4.0
     date-fns: ^2.30.0
     dexie: ^3.2.4
@@ -7593,7 +7593,7 @@ __metadata:
     vitest: ^0.34.2
     zod: ^3.22.1
   peerDependencies:
-    "@xmtp/xmtp-js": ^10.2.1
+    "@xmtp/xmtp-js": ^11.0.0-beta.8
     react: ">=16.14"
   languageName: unknown
   linkType: soft
@@ -7604,17 +7604,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/xmtp-js@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "@xmtp/xmtp-js@npm:10.2.0"
+"@xmtp/xmtp-js@npm:^11.0.0-beta.8":
+  version: 11.0.0-beta.8
+  resolution: "@xmtp/xmtp-js@npm:11.0.0-beta.8"
   dependencies:
     "@noble/secp256k1": ^1.5.2
-    "@xmtp/proto": ^3.24.0
+    "@xmtp/proto": ^3.28.0-beta.1
     async-mutex: ^0.4.0
     elliptic: ^6.5.4
     ethers: ^5.5.3
     long: ^5.2.0
-  checksum: 116a34b4232c817494f292082d24c5ab84ec4536203b950e7cc079a4acbe5b43da594a6e52bffacab51cea3a4b00ac006dec9f32aba69919acf5098c5b22cf2a
+  checksum: 2b2f1c1e7cd5aa202246a57728ea40024056a63ba1bceaa07bc5a9e5ab6d7308ebadbc64baaa730a43d5160f90173651f774eb89b86ca8e23088446eadc72f8a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7421,15 +7421,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-read-receipt@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@xmtp/content-type-read-receipt@npm:1.0.1"
+"@xmtp/content-type-reaction@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@xmtp/content-type-reaction@npm:1.1.0"
+  dependencies:
+    "@xmtp/xmtp-js": ^9.1.7
+  peerDependencies:
+    "@xmtp/xmtp-js": ^9.1.7
+  checksum: 0a01e35c53e7719045e72e196e8931475fefc39dba277923410f4f94a1f7bcaa8bd25d9829039d2d4bc98570597bdd963c0c4f2976240c81248f52093e083ffb
+  languageName: node
+  linkType: hard
+
+"@xmtp/content-type-read-receipt@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@xmtp/content-type-read-receipt@npm:1.1.0"
   dependencies:
     "@xmtp/proto": ^3.26.0
     "@xmtp/xmtp-js": ^9.2.0
   peerDependencies:
     "@xmtp/xmtp-js": ^9.2.0
-  checksum: 106445a2fd5ce6c6535abb646fefaf912f4ef434abe5226e6395fc41571e92863c8854ece8c619eccfce785ae3305e07e3f56b71350fff9d0ab874ebe6d46d07
+  checksum: 337b23b3c7479444bace54149e20719e13eecc18fa81b17da741553f81121a29e491196de6cffb61c9885c17106b08584ee6f4d194e5050164e4a0fc465a19b9
   languageName: node
   linkType: hard
 
@@ -7446,6 +7457,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmtp/content-type-remote-attachment@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@xmtp/content-type-remote-attachment@npm:1.1.0"
+  dependencies:
+    "@noble/secp256k1": ^1.7.1
+    "@xmtp/proto": ^3.25.0
+    "@xmtp/xmtp-js": ^9.1.7
+  peerDependencies:
+    "@xmtp/xmtp-js": ^9.1.7
+  checksum: 02c3693f7653bce1d24dc46fca8a400fd2493c4b843bcb2e7b8f53a2919ef3d617d8af4eefd092a73295bb2f4b8a33a376266adf74966a846a050923c4382e31
+  languageName: node
+  linkType: hard
+
 "@xmtp/content-type-reply@npm:^1.0.0":
   version: 1.0.0
   resolution: "@xmtp/content-type-reply@npm:1.0.0"
@@ -7455,6 +7479,18 @@ __metadata:
   peerDependencies:
     "@xmtp/xmtp-js": ^9.2.0
   checksum: 7f204eab598d55a755d88328cd957aa713dad7281437ced0113a29801f67d759e8d2ac1852e69874b7ab72bc9f29e2a10a52cf105ae1a8aab5126ad0ce0a0758
+  languageName: node
+  linkType: hard
+
+"@xmtp/content-type-reply@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@xmtp/content-type-reply@npm:1.1.0"
+  dependencies:
+    "@xmtp/proto": ^3.26.0
+    "@xmtp/xmtp-js": ^9.2.0
+  peerDependencies:
+    "@xmtp/xmtp-js": ^9.2.0
+  checksum: df1737da76281539e2a2d7303887ddd18c8c66c9035f0d07d4f1c922806476cdbfad1322e710d29a42d11a852025d2ff44db0ecd08d3f5e42df36baaab426280
   languageName: node
   linkType: hard
 
@@ -7566,10 +7602,10 @@ __metadata:
     "@types/uuid": ^9.0.2
     "@vitejs/plugin-react": ^4.0.4
     "@vitest/coverage-v8": ^0.34.2
-    "@xmtp/content-type-reaction": ^1.0.1
-    "@xmtp/content-type-read-receipt": ^1.0.1
-    "@xmtp/content-type-remote-attachment": ^1.0.7
-    "@xmtp/content-type-reply": ^1.0.0
+    "@xmtp/content-type-reaction": ^1.1.0
+    "@xmtp/content-type-read-receipt": ^1.1.0
+    "@xmtp/content-type-remote-attachment": ^1.1.0
+    "@xmtp/content-type-reply": ^1.1.0
     "@xmtp/tsconfig": "workspace:*"
     "@xmtp/xmtp-js": ^11.0.0-beta.8
     async-mutex: ^0.4.0


### PR DESCRIPTION
## Summary

Creates a branch using `xmtp-js` v11. Goal here is to pre-release a v11 version of the React SDK so that we can test it in inbox web.