### PR TITLE
Export more functions, rename `hasTopic`

### DIFF
--- a/.changeset/shy-birds-yell.md
+++ b/.changeset/shy-birds-yell.md
@@ -1,0 +1,6 @@
+---
+"@xmtp/react-sdk": patch
+---
+
+- Rename `hasTopic` => `hasConversationTopic`
+- Add exports for `hasConversationTopic`, `saveConversation`, `setConversationUpdatedAt`, `updateConversation`, `updateConversationMetadata`, `deleteMessage`, `getLastMessage`, `saveMessage`, `updateMessage`, and `updateMessageMetadata`

--- a/packages/react-sdk/src/helpers/caching/conversations.test.ts
+++ b/packages/react-sdk/src/helpers/caching/conversations.test.ts
@@ -7,7 +7,7 @@ import {
   getCachedConversationByPeerAddress,
   getCachedConversationByTopic,
   getConversationByTopic,
-  hasTopic,
+  hasConversationTopic,
   saveConversation,
   setConversationUpdatedAt,
   toCachedConversation,
@@ -198,7 +198,7 @@ describe("setConversationUpdatedAt", () => {
   });
 });
 
-describe("hasTopic", () => {
+describe("hasConversationTopic", () => {
   it("should return true if the topic exists", async () => {
     const createdAt = new Date();
     const testConversation = {
@@ -213,11 +213,11 @@ describe("hasTopic", () => {
     const cachedConversation = await saveConversation(testConversation, db);
     expect(cachedConversation).toEqual(testConversation);
 
-    expect(await hasTopic("testTopic", db)).toBe(true);
+    expect(await hasConversationTopic("testTopic", db)).toBe(true);
   });
 
   it("should return false if the topic does not exist", async () => {
-    expect(await hasTopic("testTopic", db)).toBe(false);
+    expect(await hasConversationTopic("testTopic", db)).toBe(false);
   });
 });
 

--- a/packages/react-sdk/src/helpers/caching/conversations.ts
+++ b/packages/react-sdk/src/helpers/caching/conversations.ts
@@ -148,7 +148,7 @@ export const setConversationUpdatedAt = async (
 /**
  * Check to see if a topic exists in the conversations cache
  */
-export const hasTopic = async (topic: string, db: Dexie) => {
+export const hasConversationTopic = async (topic: string, db: Dexie) => {
   const existing = await getCachedConversationByTopic(topic, db);
   return !!existing;
 };

--- a/packages/react-sdk/src/hooks/useConversation.ts
+++ b/packages/react-sdk/src/hooks/useConversation.ts
@@ -4,7 +4,7 @@ import type { CachedConversation } from "@/helpers/caching/conversations";
 import {
   getCachedConversationByTopic,
   getConversationByTopic,
-  hasTopic as _hasTopic,
+  hasConversationTopic as _hasConversationTopic,
   saveConversation as _saveConversation,
   updateConversation as _updateConversation,
   updateConversationMetadata,
@@ -84,16 +84,15 @@ export const useConversation = () => {
     RemoveLastParameter<typeof _getLastMessage>
   >(async (topic) => _getLastMessage(topic, db), [db]);
 
-  const hasTopic = useCallback<RemoveLastParameter<typeof _hasTopic>>(
-    async (topic) => _hasTopic(topic, db),
-    [db],
-  );
+  const hasConversationTopic = useCallback<
+    RemoveLastParameter<typeof _hasConversationTopic>
+  >(async (topic) => _hasConversationTopic(topic, db), [db]);
 
   return {
     getByTopic,
     getCachedByTopic,
     getCachedByPeerAddress,
     getLastMessage,
-    hasTopic,
+    hasConversationTopic,
   };
 };

--- a/packages/react-sdk/src/hooks/useConversations.ts
+++ b/packages/react-sdk/src/hooks/useConversations.ts
@@ -28,7 +28,7 @@ export const useConversations = (options?: UseConversationsOptions) => {
   const { client } = useClient();
   const { processMessage } = useMessage();
   const { saveConversation } = useConversationInternal();
-  const { hasTopic } = useConversation();
+  const { hasConversationTopic } = useConversation();
   const conversations = useCachedConversations();
   // to prevent conversations from being fetched multiple times
   const loadingRef = useRef(false);
@@ -66,7 +66,7 @@ export const useConversations = (options?: UseConversationsOptions) => {
           conversationList.map(async (conversation) => {
             // only save the conversation and fetch its latest message if it
             // doesn't already exist
-            if (!(await hasTopic(conversation.topic))) {
+            if (!(await hasConversationTopic(conversation.topic))) {
               const cachedConversation = await saveConversation(
                 toCachedConversation(conversation, client.address),
               );
@@ -106,7 +106,7 @@ export const useConversations = (options?: UseConversationsOptions) => {
     client,
     saveConversation,
     processMessage,
-    hasTopic,
+    hasConversationTopic,
   ]);
 
   return {

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -55,7 +55,12 @@ export {
   getCachedConversationByPeerAddress,
   getCachedConversationByTopic,
   getConversationByTopic,
+  hasConversationTopic,
+  saveConversation,
+  setConversationUpdatedAt,
   toCachedConversation,
+  updateConversation,
+  updateConversationMetadata,
 } from "./helpers/caching/conversations";
 
 // messages
@@ -66,8 +71,13 @@ export type {
   ProcessUnprocessedMessagesOptions,
 } from "./helpers/caching/messages";
 export {
+  deleteMessage,
+  getLastMessage,
   getMessageByXmtpID,
+  saveMessage,
   toCachedMessage,
+  updateMessage,
+  updateMessageMetadata,
 } from "./helpers/caching/messages";
 
 // attachments


### PR DESCRIPTION
This PR includes the following changes:

* Rename `hasTopic` => `hasConversationTopic`
* Add exports for `hasConversationTopic`, `saveConversation`, `setConversationUpdatedAt`, `updateConversation`, `updateConversationMetadata`, `deleteMessage`, `getLastMessage`, `saveMessage`, `updateMessage`, and `updateMessageMetadata`