### PR TITLE
Add `isLoaded` states, `clearCache` export

### DIFF
--- a/.changeset/chilled-cougars-beg.md
+++ b/.changeset/chilled-cougars-beg.md
@@ -1,0 +1,7 @@
+---
+"@xmtp/react-sdk": patch
+---
+
+- Add `isLoaded` state to the `useMessages` and `useConversations` hooks
+- Add `clearCache` to exports
+- Minor refactor of `useStartConversation` hook to export `conversation` when no initial message is sent

--- a/.changeset/chilled-cougars-beg.md
+++ b/.changeset/chilled-cougars-beg.md
@@ -5,3 +5,4 @@
 - Add `isLoaded` state to the `useMessages` and `useConversations` hooks
 - Add `clearCache` to exports
 - Minor refactor of `useStartConversation` hook to export `conversation` when no initial message is sent
+- Access all cached conversations using the client's wallet address

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -5,13 +5,9 @@ services:
     environment:
       - GOWAKU-NODEKEY=8a30dcb604b0b53627a5adc054dbf434b446628d4bd1eccc681d223f0550ce67
     command:
-      - --ws
-      - --store
-      - --message-db-connection-string=postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
-      - --message-db-reader-connection-string=postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
-      - --lightpush
-      - --filter
-      - --ws-port=9001
+      - --store.enable
+      - --store.db-connection-string=postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
+      - --store.reader-db-connection-string=postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
       - --wait-for-db=30s
       - --api.authn.enable
     ports:

--- a/packages/react-sdk/src/helpers/caching/conversations.test.ts
+++ b/packages/react-sdk/src/helpers/caching/conversations.test.ts
@@ -31,22 +31,34 @@ beforeEach(async () => {
 describe("getCachedConversationBy", () => {
   it("should return undefined if no conversation is found", async () => {
     const conversation = await getCachedConversationBy(
+      "testWalletAddress",
       "topic",
       "testTopic",
       db,
     );
     expect(conversation).toBeUndefined();
-    const conversation2 = await getCachedConversationBy("id", 1, db);
+    const conversation2 = await getCachedConversationBy(
+      "testWalletAddress",
+      "id",
+      1,
+      db,
+    );
     expect(conversation2).toBeUndefined();
     const conversation3 = await getCachedConversationBy(
+      "testWalletAddress",
       "peerAddress",
       "testPeerAddress",
       db,
     );
     expect(conversation3).toBeUndefined();
-    const conversation4 = await getCachedConversationByTopic("testTopic", db);
+    const conversation4 = await getCachedConversationByTopic(
+      "testWalletAddress",
+      "testTopic",
+      db,
+    );
     expect(conversation4).toBeUndefined();
     const conversation5 = await getCachedConversationByPeerAddress(
+      "testWalletAddress",
       "testPeerAddress",
       db,
     );
@@ -65,22 +77,34 @@ describe("getCachedConversationBy", () => {
     } satisfies CachedConversationWithId;
     const cachedConversation = await saveConversation(testConversation, db);
     const conversation = await getCachedConversationBy(
+      "testWalletAddress",
       "topic",
       "testTopic",
       db,
     );
     expect(conversation).toEqual(cachedConversation);
-    const conversation2 = await getCachedConversationBy("id", 1, db);
+    const conversation2 = await getCachedConversationBy(
+      "testWalletAddress",
+      "id",
+      1,
+      db,
+    );
     expect(conversation2).toEqual(cachedConversation);
     const conversation3 = await getCachedConversationBy(
+      "testWalletAddress",
       "peerAddress",
       "testPeerAddress",
       db,
     );
     expect(conversation3).toEqual(cachedConversation);
-    const conversation4 = await getCachedConversationByTopic("testTopic", db);
+    const conversation4 = await getCachedConversationByTopic(
+      "testWalletAddress",
+      "testTopic",
+      db,
+    );
     expect(conversation4).toEqual(cachedConversation);
     const conversation5 = await getCachedConversationByPeerAddress(
+      "testWalletAddress",
       "testPeerAddress",
       db,
     );
@@ -138,6 +162,7 @@ describe("updateConversation", () => {
     );
 
     const updatedConversation = await getCachedConversationByTopic(
+      "testWalletAddress",
       "testTopic",
       db,
     );
@@ -163,9 +188,16 @@ describe("updateConversationMetadata", () => {
     const cachedConversation = await saveConversation(testConversation, db);
     expect(cachedConversation).toEqual(testConversation);
 
-    await updateConversationMetadata("testTopic", "test", { test: "test" }, db);
+    await updateConversationMetadata(
+      "testWalletAddress",
+      "testTopic",
+      "test",
+      { test: "test" },
+      db,
+    );
 
     const updatedConversation = await getCachedConversationByTopic(
+      "testWalletAddress",
       "testTopic",
       db,
     );
@@ -193,7 +225,11 @@ describe("setConversationUpdatedAt", () => {
 
     await setConversationUpdatedAt("testTopic", updatedAt, db);
 
-    const conversation = await getCachedConversationByTopic("testTopic", db);
+    const conversation = await getCachedConversationByTopic(
+      "testWalletAddress",
+      "testTopic",
+      db,
+    );
     expect(conversation?.updatedAt).toEqual(updatedAt);
   });
 });
@@ -213,11 +249,15 @@ describe("hasConversationTopic", () => {
     const cachedConversation = await saveConversation(testConversation, db);
     expect(cachedConversation).toEqual(testConversation);
 
-    expect(await hasConversationTopic("testTopic", db)).toBe(true);
+    expect(
+      await hasConversationTopic("testWalletAddress", "testTopic", db),
+    ).toBe(true);
   });
 
   it("should return false if the topic does not exist", async () => {
-    expect(await hasConversationTopic("testTopic", db)).toBe(false);
+    expect(
+      await hasConversationTopic("testWalletAddress", "testTopic", db),
+    ).toBe(false);
   });
 });
 

--- a/packages/react-sdk/src/helpers/caching/db.ts
+++ b/packages/react-sdk/src/helpers/caching/db.ts
@@ -92,7 +92,8 @@ export const getDbInstance = (options?: GetDBInstanceOptions) => {
       ...customSchema,
       conversations: `
         ++id,
-        [topic+walletAddress],
+        [walletAddress+topic],
+        [walletAddress+peerAddress],
         createdAt,
         peerAddress,
         topic,

--- a/packages/react-sdk/src/helpers/caching/messages.test.ts
+++ b/packages/react-sdk/src/helpers/caching/messages.test.ts
@@ -541,6 +541,7 @@ describe("processMessage", () => {
     expect(mockProcessor3).not.toHaveBeenCalled();
 
     const updatedConversation = await getCachedConversationByTopic(
+      "testWalletAddress",
       "testTopic",
       db,
     );
@@ -594,6 +595,7 @@ describe("processMessage", () => {
     expect(mockProcessor3).not.toHaveBeenCalled();
 
     const updatedConversation = await getCachedConversationByTopic(
+      "testWalletAddress",
       "testTopic",
       db,
     );
@@ -642,6 +644,7 @@ describe("processMessage", () => {
     expect(mockProcessor3).not.toHaveBeenCalled();
 
     const updatedConversation = await getCachedConversationByTopic(
+      "testWalletAddress",
       "testTopic",
       db,
     );
@@ -882,13 +885,13 @@ describe("processMessage", () => {
       isReady: false,
       topic: "testTopic",
       peerAddress: "testPeerAddress",
-      walletAddress: "testWalletAddress",
+      walletAddress: testClient.address,
     } satisfies CachedConversation;
     const cachedConversation = await saveConversation(testConversation, db);
     const sentAt = adjustDate(createdAt, 1000);
     const testMessage = {
       id: 1,
-      walletAddress: "testWalletAddress",
+      walletAddress: testClient.address,
       conversationTopic: "testTopic",
       content: "test",
       contentType: ContentTypeText.toString(),
@@ -897,7 +900,7 @@ describe("processMessage", () => {
       hasSendError: false,
       sentAt,
       status: "unprocessed",
-      senderAddress: "testWalletAddress",
+      senderAddress: testClient.address,
       uuid: "testUuid",
       xmtpID: "testXmtpId",
     } satisfies CachedMessage;
@@ -924,6 +927,7 @@ describe("processMessage", () => {
     expect(mockProcessor3).not.toHaveBeenCalled();
 
     const updatedConversation = await getCachedConversationByTopic(
+      testClient.address,
       "testTopic",
       db,
     );

--- a/packages/react-sdk/src/helpers/caching/messages.ts
+++ b/packages/react-sdk/src/helpers/caching/messages.ts
@@ -325,6 +325,7 @@ export const processMessage = async (
       data: ContentTypeMetadataValues,
     ) => {
       await _updateConversationMetadata(
+        client.address,
         conversation.topic,
         namespace,
         data,
@@ -503,6 +504,7 @@ export const processUnprocessedMessages = async ({
     unprocessed.map(async (unprocessedMessage) => {
       // get message's conversation from cache
       const conversation = await getCachedConversationByTopic(
+        client.address,
         unprocessedMessage.conversationTopic,
         db,
       );

--- a/packages/react-sdk/src/hooks/useConversation.ts
+++ b/packages/react-sdk/src/hooks/useConversation.ts
@@ -37,9 +37,17 @@ export const useConversationInternal = () => {
     RemoveLastParameter<typeof updateConversationMetadata>
   >(
     async (conversation, namespace, data) => {
-      await updateConversationMetadata(conversation, namespace, data, db);
+      if (client) {
+        await updateConversationMetadata(
+          client.address,
+          conversation,
+          namespace,
+          data,
+          db,
+        );
+      }
     },
-    [db],
+    [client, db],
   );
 
   return {
@@ -57,36 +65,38 @@ export const useConversation = () => {
   const { client } = useClient();
   const { db } = useDb();
 
-  const getByTopic = useCallback<
-    RemoveLastParameter<typeof getConversationByTopic>
-  >(
-    async (topic) => {
-      if (client) {
-        return getConversationByTopic(topic, client);
-      }
-      return undefined;
-    },
+  const getByTopic = useCallback(
+    async (topic: string) =>
+      client ? getConversationByTopic(topic, client) : undefined,
     [client],
   );
 
-  const getCachedByTopic = useCallback<
-    RemoveLastParameter<typeof getCachedConversationByTopic>
-  >(async (topic) => getCachedConversationByTopic(topic, db), [db]);
+  const getCachedByTopic = useCallback(
+    async (topic: string) =>
+      client
+        ? getCachedConversationByTopic(client.address, topic, db)
+        : undefined,
+    [client, db],
+  );
 
-  const getCachedByPeerAddress = useCallback<
-    RemoveLastParameter<typeof getCachedConversationByPeerAddress>
-  >(
-    async (peerAddress) => getCachedConversationByPeerAddress(peerAddress, db),
+  const getCachedByPeerAddress = useCallback(
+    async (peerAddress: string) =>
+      client
+        ? getCachedConversationByPeerAddress(client.address, peerAddress, db)
+        : undefined,
+    [client, db],
+  );
+
+  const getLastMessage = useCallback(
+    async (topic: string) => _getLastMessage(topic, db),
     [db],
   );
 
-  const getLastMessage = useCallback<
-    RemoveLastParameter<typeof _getLastMessage>
-  >(async (topic) => _getLastMessage(topic, db), [db]);
-
-  const hasConversationTopic = useCallback<
-    RemoveLastParameter<typeof _hasConversationTopic>
-  >(async (topic) => _hasConversationTopic(topic, db), [db]);
+  const hasConversationTopic = useCallback(
+    async (topic: string) =>
+      client ? _hasConversationTopic(client.address, topic, db) : false,
+    [client, db],
+  );
 
   return {
     getByTopic,

--- a/packages/react-sdk/src/hooks/useConversations.ts
+++ b/packages/react-sdk/src/hooks/useConversations.ts
@@ -24,6 +24,7 @@ export type UseConversationsOptions = OnError & {
  */
 export const useConversations = (options?: UseConversationsOptions) => {
   const [isLoading, setIsLoading] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const { client } = useClient();
   const { processMessage } = useMessage();
@@ -58,6 +59,7 @@ export const useConversations = (options?: UseConversationsOptions) => {
       loadingRef.current = true;
 
       setIsLoading(true);
+      setIsLoaded(false);
       setError(null);
 
       try {
@@ -87,6 +89,7 @@ export const useConversations = (options?: UseConversationsOptions) => {
             }
           }),
         );
+        setIsLoaded(true);
         onConversations?.(conversationList);
       } catch (e) {
         setError(e as Error);
@@ -112,6 +115,7 @@ export const useConversations = (options?: UseConversationsOptions) => {
   return {
     conversations,
     error,
+    isLoaded,
     isLoading,
   };
 };

--- a/packages/react-sdk/src/hooks/useMessages.ts
+++ b/packages/react-sdk/src/hooks/useMessages.ts
@@ -27,6 +27,7 @@ export const useMessages = (
   conversation: CachedConversation,
   options?: UseMessagesOptions,
 ) => {
+  const [isLoaded, setIsLoaded] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const { processMessage } = useMessage();
@@ -57,8 +58,9 @@ export const useMessages = (
 
     loadingRef.current = true;
 
-    // reset loading state
+    // reset loading states
     setIsLoading(true);
+    setIsLoaded(false);
     // reset error state
     setError(null);
 
@@ -96,6 +98,7 @@ export const useMessages = (
         await updateConversation(conversation.topic, { isReady: true });
       }
 
+      setIsLoaded(true);
       onMessages?.(networkMessages);
     } catch (e) {
       setError(e as Error);
@@ -122,6 +125,7 @@ export const useMessages = (
 
   return {
     error,
+    isLoaded,
     isLoading,
     messages,
   };

--- a/packages/react-sdk/src/hooks/useStartConversation.ts
+++ b/packages/react-sdk/src/hooks/useStartConversation.ts
@@ -61,19 +61,19 @@ export const useStartConversation = (options?: UseStartConversation) => {
           toCachedConversation(conversation, client.address),
         );
 
-        if (content === undefined) {
-          return {
-            cachedConversation,
-            cachedMessage: undefined,
-            conversation: undefined,
-          };
-        }
-
         if (!cachedConversation) {
           return {
             cachedConversation: undefined,
             cachedMessage: undefined,
-            conversation: undefined,
+            conversation,
+          };
+        }
+
+        if (content === undefined) {
+          return {
+            cachedConversation,
+            cachedMessage: undefined,
+            conversation,
           };
         }
 

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -33,7 +33,7 @@ export { useReactions } from "./hooks/useReactions";
 export { useReply } from "./hooks/useReply";
 
 // caching
-export { getDbInstance } from "./helpers/caching/db";
+export { getDbInstance, clearCache } from "./helpers/caching/db";
 
 export type {
   ContentTypeMetadataValue,


### PR DESCRIPTION
This PR does the following:

* Add `isLoaded` state to the `useMessages` and `useConversations` hooks
* Add `clearCache` to exports
* Minor refactor of `useStartConversation` hook to export `conversation` when no initial message is sent
* Use the client's wallet address to access all cached conversations