### PR TITLE
Lowercase all addresses

### DIFF
--- a/.changeset/sharp-pianos-promise.md
+++ b/.changeset/sharp-pianos-promise.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-sdk": patch
+---
+
+- Store all wallet addresses in lowercase to allow for consistent results when querying the local cache

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reaction.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reaction.test.ts
@@ -140,7 +140,7 @@ describe("ContentTypeReaction caching", () => {
         testReactionContent.reference,
       );
       expect(reactions[0].schema).toEqual(testReactionContent.schema);
-      expect(reactions[0].senderAddress).toBe("testWalletAddress");
+      expect(reactions[0].senderAddress).toBe("testwalletaddress");
       expect(reactions[0].xmtpID).toEqual("testXmtpId2");
 
       const originalMessage = await getMessageByXmtpID("testXmtpId1", db);

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reaction.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reaction.ts
@@ -53,7 +53,7 @@ export const findReaction = async (reaction: CachedReaction, db: Dexie) => {
     content: reaction.content,
     referenceXmtpID: reaction.referenceXmtpID,
     schema: reaction.schema,
-    senderAddress: reaction.senderAddress,
+    senderAddress: reaction.senderAddress.toLowerCase(),
   };
 
   const found = await reactionsTable.where(reactionQuery).first();
@@ -78,7 +78,10 @@ export const saveReaction = async (reaction: CachedReaction, db: Dexie) => {
     return existing.id;
   }
 
-  return reactionsTable.add(reaction);
+  return reactionsTable.add({
+    ...reaction,
+    senderAddress: reaction.senderAddress.toLowerCase(),
+  });
 };
 
 /**

--- a/packages/react-sdk/src/helpers/caching/conversations.test.ts
+++ b/packages/react-sdk/src/helpers/caching/conversations.test.ts
@@ -147,7 +147,11 @@ describe("updateConversation", () => {
       walletAddress: "testWalletAddress",
     } satisfies CachedConversationWithId;
     const cachedConversation = await saveConversation(testConversation, db);
-    expect(cachedConversation).toEqual(testConversation);
+    expect(cachedConversation).toEqual({
+      ...testConversation,
+      peerAddress: testConversation.peerAddress.toLowerCase(),
+      walletAddress: testConversation.walletAddress.toLowerCase(),
+    });
 
     const updatedAt = adjustDate(createdAt, 1000);
 
@@ -186,7 +190,11 @@ describe("updateConversationMetadata", () => {
       walletAddress: "testWalletAddress",
     } satisfies CachedConversationWithId;
     const cachedConversation = await saveConversation(testConversation, db);
-    expect(cachedConversation).toEqual(testConversation);
+    expect(cachedConversation).toEqual({
+      ...testConversation,
+      peerAddress: testConversation.peerAddress.toLowerCase(),
+      walletAddress: testConversation.walletAddress.toLowerCase(),
+    });
 
     await updateConversationMetadata(
       "testWalletAddress",
@@ -247,7 +255,11 @@ describe("hasConversationTopic", () => {
       walletAddress: "testWalletAddress",
     } satisfies CachedConversationWithId;
     const cachedConversation = await saveConversation(testConversation, db);
-    expect(cachedConversation).toEqual(testConversation);
+    expect(cachedConversation).toEqual({
+      ...testConversation,
+      peerAddress: testConversation.peerAddress.toLowerCase(),
+      walletAddress: testConversation.walletAddress.toLowerCase(),
+    });
 
     expect(
       await hasConversationTopic("testWalletAddress", "testTopic", db),
@@ -274,12 +286,17 @@ describe("saveConversation", () => {
       walletAddress: "testWalletAddress",
     } satisfies CachedConversationWithId;
     const cachedConversation = await saveConversation(testConversation, db);
-    expect(cachedConversation).toEqual(testConversation);
+    expect(cachedConversation).toEqual({
+      ...testConversation,
+      peerAddress: testConversation.peerAddress.toLowerCase(),
+      walletAddress: testConversation.walletAddress.toLowerCase(),
+    });
   });
 
   it("should return a duplicate conversation", async () => {
     const createdAt = new Date();
     const testConversation = {
+      id: 1,
       createdAt,
       updatedAt: createdAt,
       isReady: false,
@@ -288,9 +305,17 @@ describe("saveConversation", () => {
       walletAddress: "testWalletAddress",
     } satisfies CachedConversation;
     const cachedConversation = await saveConversation(testConversation, db);
-    expect(cachedConversation).toEqual(testConversation);
+    expect(cachedConversation).toEqual({
+      ...testConversation,
+      peerAddress: testConversation.peerAddress.toLowerCase(),
+      walletAddress: testConversation.walletAddress.toLowerCase(),
+    });
     const cachedConversation2 = await saveConversation(testConversation, db);
-    expect(cachedConversation2).toEqual(testConversation);
+    expect(cachedConversation2).toEqual({
+      ...testConversation,
+      peerAddress: testConversation.peerAddress.toLowerCase(),
+      walletAddress: testConversation.walletAddress.toLowerCase(),
+    });
     expect(cachedConversation2.id).toBe(cachedConversation.id);
   });
 });
@@ -311,10 +336,10 @@ describe("toCachedConversation", () => {
       context: undefined,
       createdAt: testConversation.createdAt,
       isReady: false,
-      peerAddress: testConversation.peerAddress,
+      peerAddress: testConversation.peerAddress.toLowerCase(),
       topic: testConversation.topic,
       updatedAt: testConversation.createdAt,
-      walletAddress: testWallet1.address,
+      walletAddress: testWallet1.address.toLowerCase(),
     });
   });
 });

--- a/packages/react-sdk/src/helpers/caching/messages.test.ts
+++ b/packages/react-sdk/src/helpers/caching/messages.test.ts
@@ -67,9 +67,9 @@ describe("toCachedMessage", () => {
     expect(cachedMessage.status).toBe("unprocessed");
     expect(cachedMessage.hasSendError).toBe(false);
     expect(cachedMessage.isSending).toBe(false);
-    expect(cachedMessage.senderAddress).toBe("testSenderAddress");
+    expect(cachedMessage.senderAddress).toBe("testsenderaddress");
     expect(cachedMessage.sentAt).toBe(sentAt);
-    expect(cachedMessage.walletAddress).toBe("testWalletAddress");
+    expect(cachedMessage.walletAddress).toBe("testwalletaddress");
     expect(cachedMessage.xmtpID).toBe("testId");
   });
 });
@@ -117,14 +117,19 @@ describe("saveMessage", () => {
     } satisfies CachedMessage;
 
     const cachedMessage = await saveMessage(testMessage, db);
-    expect(cachedMessage).toEqual(testMessage);
+    expect(cachedMessage).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
 
     const message = await getMessageByXmtpID("testXmtpId", db);
-    expect(message).toEqual(testMessage);
+    expect(message).toEqual(cachedMessage);
   });
 
   it("should return a duplicate message", async () => {
     const testMessage = {
+      id: 1,
       walletAddress: "testWalletAddress",
       conversationTopic: "testTopic",
       content: "test",
@@ -139,9 +144,17 @@ describe("saveMessage", () => {
       xmtpID: "testXmtpId",
     } satisfies CachedMessage;
     const cachedMessage = await saveMessage(testMessage, db);
-    expect(cachedMessage).toEqual(testMessage);
+    expect(cachedMessage).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
     const cachedMessage2 = await saveMessage(testMessage, db);
-    expect(cachedMessage2).toEqual(testMessage);
+    expect(cachedMessage2).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
     expect(cachedMessage.id).toBe(cachedMessage2.id);
   });
 });
@@ -166,7 +179,11 @@ describe("deleteMessage", () => {
 
     await saveMessage(testMessage, db);
     const message = await getMessageByXmtpID("testXmtpId", db);
-    expect(message).toEqual(testMessage);
+    expect(message).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
 
     if (message) {
       await deleteMessage(message, db);
@@ -195,7 +212,11 @@ describe("updateMessage", () => {
     } satisfies CachedMessage;
 
     const cachedMessage = await saveMessage(testMessage, db);
-    expect(cachedMessage).toEqual(testMessage);
+    expect(cachedMessage).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
 
     await updateMessage(
       cachedMessage,
@@ -212,6 +233,8 @@ describe("updateMessage", () => {
       ...testMessage,
       isSending: false,
       status: "processed",
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
     });
   });
 });
@@ -235,7 +258,11 @@ describe("updateMessageMetadata", () => {
     } satisfies CachedMessage;
 
     const cachedMessage = await saveMessage(testMessage, db);
-    expect(cachedMessage).toEqual(testMessage);
+    expect(cachedMessage).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
 
     await updateMessageMetadata(
       cachedMessage,
@@ -296,7 +323,7 @@ describe("prepareMessageForSending", () => {
     expect(preparedMessage.hasSendError).toBe(false);
     expect(preparedMessage.isSending).toBe(true);
     expect(preparedMessage.status).toBe("unprocessed");
-    expect(preparedMessage.walletAddress).toBe("testWalletAddress");
+    expect(preparedMessage.walletAddress).toBe("testwalletaddress");
   });
 
   it("should prepare a message for sending without a content type", () => {
@@ -320,7 +347,7 @@ describe("prepareMessageForSending", () => {
     expect(preparedMessage.hasSendError).toBe(false);
     expect(preparedMessage.isSending).toBe(true);
     expect(preparedMessage.status).toBe("unprocessed");
-    expect(preparedMessage.walletAddress).toBe("testWalletAddress");
+    expect(preparedMessage.walletAddress).toBe("testwalletaddress");
   });
 });
 
@@ -343,7 +370,11 @@ describe("updateMessageAfterSending", () => {
     } satisfies CachedMessage;
 
     const cachedMessage = await saveMessage(testMessage, db);
-    expect(cachedMessage).toEqual(testMessage);
+    expect(cachedMessage).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
 
     const sentAt = new Date();
 
@@ -353,6 +384,8 @@ describe("updateMessageAfterSending", () => {
 
     expect(updatedMessage).toEqual({
       ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
       sentAt,
       xmtpID: "testXmtpId2",
       isSending: false,
@@ -397,9 +430,17 @@ describe("getLastMessage", () => {
     } satisfies CachedMessage;
 
     const cachedMessage = await saveMessage(testMessage, db);
-    expect(cachedMessage).toEqual(testMessage);
+    expect(cachedMessage).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
     const cachedMessage2 = await saveMessage(testMessage2, db);
-    expect(cachedMessage2).toEqual(testMessage2);
+    expect(cachedMessage2).toEqual({
+      ...testMessage2,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
 
     const lastMessage = await getLastMessage("testTopic", db);
     expect(lastMessage).toEqual(cachedMessage2);
@@ -442,13 +483,25 @@ describe("getUnprocessedMessages", () => {
     } satisfies CachedMessage;
 
     const cachedMessage = await saveMessage(testMessage, db);
-    expect(cachedMessage).toEqual(testMessage);
+    expect(cachedMessage).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
     const cachedMessage2 = await saveMessage(testMessage2, db);
-    expect(cachedMessage2).toEqual(testMessage2);
+    expect(cachedMessage2).toEqual({
+      ...testMessage2,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
 
     const unprocessedMessages = await getUnprocessedMessages(db);
     expect(unprocessedMessages.length).toBe(1);
-    expect(unprocessedMessages[0]).toEqual(testMessage2);
+    expect(unprocessedMessages[0]).toEqual({
+      ...testMessage2,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
   });
 });
 
@@ -511,7 +564,11 @@ describe("processMessage", () => {
       processors: testProcessors,
       validators: testValidators,
     });
-    expect(cachedMessage).toEqual(testMessage);
+    expect(cachedMessage).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
     expect(mockProcessor1).toHaveBeenCalledTimes(1);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(mockProcessor1.mock.calls[0][0].client).toBe(testClient);
@@ -522,7 +579,7 @@ describe("processMessage", () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(mockProcessor1.mock.calls[0][0].db).toBe(db);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(mockProcessor1.mock.calls[0][0].message).toBe(cachedMessage);
+    expect(mockProcessor1.mock.calls[0][0].message).toBe(testMessage);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(mockProcessor1.mock.calls[0][0].processors).toBe(testProcessors);
     expect(mockProcessor2).toHaveBeenCalledTimes(1);
@@ -535,7 +592,7 @@ describe("processMessage", () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(mockProcessor2.mock.calls[0][0].db).toBe(db);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(mockProcessor2.mock.calls[0][0].message).toBe(cachedMessage);
+    expect(mockProcessor2.mock.calls[0][0].message).toBe(testMessage);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(mockProcessor2.mock.calls[0][0].processors).toBe(testProcessors);
     expect(mockProcessor3).not.toHaveBeenCalled();
@@ -589,7 +646,11 @@ describe("processMessage", () => {
       processors: testProcessors,
       validators: testValidators,
     });
-    expect(cachedMessage).toEqual(testMessage);
+    expect(cachedMessage).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
     expect(mockProcessor1).not.toHaveBeenCalled();
     expect(mockProcessor2).not.toHaveBeenCalled();
     expect(mockProcessor3).not.toHaveBeenCalled();
@@ -638,7 +699,11 @@ describe("processMessage", () => {
       processors: testProcessors,
       validators: textContentTypeConfig.validators ?? {},
     });
-    expect(cachedMessage).toEqual(testMessage);
+    expect(cachedMessage).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
     expect(mockProcessor1).not.toHaveBeenCalled();
     expect(mockProcessor2).not.toHaveBeenCalled();
     expect(mockProcessor3).not.toHaveBeenCalled();
@@ -680,7 +745,11 @@ describe("processMessage", () => {
       xmtpID: "testXmtpId",
     } satisfies CachedMessage;
     const savedMessage = await saveMessage(testMessage, db);
-    expect(savedMessage).toEqual(testMessage);
+    expect(savedMessage).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
     const cachedMessage = await processMessage(
       {
         client: testClient,
@@ -693,7 +762,11 @@ describe("processMessage", () => {
       },
       true,
     );
-    expect(cachedMessage).toEqual(testMessage);
+    expect(cachedMessage).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
     expect(mockProcessor1).toHaveBeenCalled();
     expect(mockProcessor2).toHaveBeenCalled();
     expect(mockProcessor3).not.toHaveBeenCalled();
@@ -742,13 +815,21 @@ describe("processMessage", () => {
       },
       true,
     );
-    expect(cachedMessage).toEqual(testMessage);
+    expect(cachedMessage).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
     expect(mockProcessor1).not.toHaveBeenCalled();
     expect(mockProcessor2).not.toHaveBeenCalled();
     expect(mockProcessor3).not.toHaveBeenCalled();
 
     const savedMessage = await getMessageByXmtpID("testXmtpId", db);
-    expect(savedMessage).toEqual(testMessage);
+    expect(savedMessage).toEqual({
+      ...testMessage,
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
+    });
   });
 
   it("should cache a message if persist is called in its processor", async () => {
@@ -795,6 +876,8 @@ describe("processMessage", () => {
     const updatedMessage = {
       ...testMessage,
       status: "processed",
+      senderAddress: "testwalletaddress",
+      walletAddress: "testwalletaddress",
     };
 
     expect(cachedMessage).toEqual(updatedMessage);
@@ -859,6 +942,8 @@ describe("processMessage", () => {
       ...testMessage,
       content: "foo",
       status: "processed",
+      senderAddress: testMessage.senderAddress.toLowerCase(),
+      walletAddress: testMessage.walletAddress.toLowerCase(),
       metadata: {
         [testNamepaces[ContentTypeText.toString()]]: {
           foo: "bar",
@@ -921,7 +1006,11 @@ describe("processMessage", () => {
       validators: testValidators,
     });
 
-    expect(cachedMessage).toEqual(testMessage);
+    expect(cachedMessage).toEqual({
+      ...testMessage,
+      senderAddress: testMessage.senderAddress.toLowerCase(),
+      walletAddress: testMessage.walletAddress.toLowerCase(),
+    });
     expect(mockProcessor1).toHaveBeenCalledTimes(1);
     expect(mockProcessor2).toHaveBeenCalledTimes(1);
     expect(mockProcessor3).not.toHaveBeenCalled();
@@ -1138,7 +1227,11 @@ describe("processUnprocessedMessages", () => {
       conversation: cachedConversation,
       client: testClient,
       db,
-      message: testMessage1,
+      message: {
+        ...testMessage1,
+        senderAddress: testMessage1.senderAddress.toLowerCase(),
+        walletAddress: testMessage1.walletAddress.toLowerCase(),
+      },
       namespaces,
       processors,
       validators,

--- a/packages/react-sdk/src/hooks/useCachedConversations.test.ts
+++ b/packages/react-sdk/src/hooks/useCachedConversations.test.ts
@@ -56,7 +56,11 @@ describe("useCachedConversations", () => {
 
     await waitFor(() => {
       expect(result.current.length).toBe(1);
-      expect(result.current[0]).toEqual(testConversation);
+      expect(result.current[0]).toEqual({
+        ...testConversation,
+        peerAddress: testPeerAddress.toLowerCase(),
+        walletAddress: testWalletAddress.toLowerCase(),
+      });
     });
   });
 });

--- a/packages/react-sdk/src/hooks/useCachedConversations.ts
+++ b/packages/react-sdk/src/hooks/useCachedConversations.ts
@@ -20,7 +20,7 @@ export const useCachedConversations = () => {
       }
       return (db.table("conversations") as CachedConversationsTable)
         .where("walletAddress")
-        .equals(client.address)
+        .equals(client.address.toLowerCase())
         .reverse()
         .sortBy("updatedAt");
     }, [client?.address]) ?? []

--- a/packages/react-sdk/src/hooks/useCachedMessages.test.ts
+++ b/packages/react-sdk/src/hooks/useCachedMessages.test.ts
@@ -63,7 +63,11 @@ describe("useCachedMessages", () => {
 
     await waitFor(() => {
       expect(result.current.length).toBe(1);
-      expect(result.current[0]).toEqual(testMessage);
+      expect(result.current[0]).toEqual({
+        ...testMessage,
+        senderAddress: testWalletAddress.toLowerCase(),
+        walletAddress: testWalletAddress.toLowerCase(),
+      });
     });
   });
 });

--- a/packages/react-sdk/src/hooks/useCachedMessages.ts
+++ b/packages/react-sdk/src/hooks/useCachedMessages.ts
@@ -21,7 +21,7 @@ export const useCachedMessages = (topic: string) => {
       return (db.table("messages") as CachedMessagesTable)
         .where({
           conversationTopic: topic,
-          walletAddress: client.address,
+          walletAddress: client.address.toLowerCase(),
         })
         .sortBy("sentAt");
     }, [topic]) ?? []

--- a/packages/react-sdk/src/hooks/useConversation.ts
+++ b/packages/react-sdk/src/hooks/useConversation.ts
@@ -39,7 +39,7 @@ export const useConversationInternal = () => {
     async (conversation, namespace, data) => {
       if (client) {
         await updateConversationMetadata(
-          client.address,
+          client.address.toLowerCase(),
           conversation,
           namespace,
           data,

--- a/packages/react-sdk/src/hooks/useLastMessage.test.ts
+++ b/packages/react-sdk/src/hooks/useLastMessage.test.ts
@@ -62,7 +62,11 @@ describe("useLastMessage", () => {
     const { result } = renderHook(() => useLastMessage(testTopic));
 
     await waitFor(() => {
-      expect(result.current).toEqual(testMessage);
+      expect(result.current).toEqual({
+        ...testMessage,
+        senderAddress: testWalletAddress.toLowerCase(),
+        walletAddress: testWalletAddress.toLowerCase(),
+      });
     });
   });
 });


### PR DESCRIPTION
This PR lowercases all wallet addresses before storing them in the cache. Since wallet addresses are case-insensitive, it's best to have everything lowercase when querying the local cache.