### PR TITLE
Upgrade to JS SDK v11

### DIFF
--- a/.changeset/brave-parrots-camp.md
+++ b/.changeset/brave-parrots-camp.md
@@ -1,5 +1,5 @@
 ---
-"@xmtp/react-sdk": patch
+"@xmtp/react-sdk": minor
 ---
 
 * Upgrade JS SDK to v11

--- a/.changeset/brave-parrots-camp.md
+++ b/.changeset/brave-parrots-camp.md
@@ -1,0 +1,9 @@
+---
+"@xmtp/react-sdk": patch
+---
+
+* Upgrade JS SDK to v11
+* Upgrade all standards-track content types
+* Replace `ethers` with `viem`
+* Update read receipt processor for updated content type
+* Update client signer type

--- a/examples/react-quickstart/package.json
+++ b/examples/react-quickstart/package.json
@@ -17,14 +17,14 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.0.18",
-    "@rainbow-me/rainbowkit": "^0.12.16",
-    "@xmtp/content-type-remote-attachment": "^1.0.7",
+    "@rainbow-me/rainbowkit": "^1.0.11",
+    "@xmtp/content-type-remote-attachment": "^1.1.2",
     "@xmtp/react-components": "workspace:*",
     "@xmtp/react-sdk": "workspace:*",
-    "ethers": "5.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wagmi": "^0.12.18"
+    "viem": "^1.12.2",
+    "wagmi": "^1.4.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.20",

--- a/examples/react-quickstart/src/components/App.tsx
+++ b/examples/react-quickstart/src/components/App.tsx
@@ -1,18 +1,18 @@
 import "./App.css";
-import { useSigner } from "wagmi";
 import { useEffect } from "react";
 import { useClient } from "@xmtp/react-sdk";
 import { ContentRouter } from "./ContentRouter";
+import { useWallet } from "../hooks/useWallet";
 
 const App = () => {
-  const { data: signer } = useSigner();
+  const { address } = useWallet();
   const { disconnect } = useClient();
 
   // disconnect XMTP client when the wallet changes
   useEffect(() => {
     void disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [signer]);
+  }, [address]);
 
   return (
     <div className="App">

--- a/examples/react-quickstart/src/components/XMTPConnect.tsx
+++ b/examples/react-quickstart/src/components/XMTPConnect.tsx
@@ -1,22 +1,22 @@
 import { LinkIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { useClient } from "@xmtp/react-sdk";
 import { useCallback } from "react";
+import { useWalletClient } from "wagmi";
 import { Notification } from "./Notification";
-import { useWallet } from "../hooks/useWallet";
 
 type XMTPConnectButtonProps = {
   label: string;
 };
 
 const XMTPConnectButton: React.FC<XMTPConnectButtonProps> = ({ label }) => {
-  const { signer } = useWallet();
   const { initialize } = useClient();
+  const { data: walletClient } = useWalletClient();
 
   const handleConnect = useCallback(() => {
     void initialize({
-      signer,
+      signer: walletClient,
     });
-  }, [initialize, signer]);
+  }, [initialize, walletClient]);
 
   return (
     <button className="Button" type="button" onClick={handleConnect}>

--- a/examples/react-quickstart/src/contexts/WalletContext.tsx
+++ b/examples/react-quickstart/src/contexts/WalletContext.tsx
@@ -1,7 +1,6 @@
 import "@rainbow-me/rainbowkit/styles.css";
-import type { Signer } from "@xmtp/react-sdk";
 import { createContext, useMemo } from "react";
-import { useAccount, useConnect, useDisconnect, useSigner } from "wagmi";
+import { useAccount, useConnect, useDisconnect } from "wagmi";
 
 export type WalletContextValue = {
   address: `0x${string}` | undefined;
@@ -9,7 +8,6 @@ export type WalletContextValue = {
   error: Error | null;
   isConnected: boolean;
   isLoading: boolean;
-  signer: Signer | undefined | null;
 };
 
 export const WalletContext = createContext<WalletContextValue>({
@@ -18,7 +16,6 @@ export const WalletContext = createContext<WalletContextValue>({
   error: null,
   isConnected: false,
   isLoading: false,
-  signer: undefined,
 });
 
 export const WalletProvider: React.FC<React.PropsWithChildren> = ({
@@ -26,15 +23,20 @@ export const WalletProvider: React.FC<React.PropsWithChildren> = ({
 }) => {
   const { address, isConnected, isConnecting, isReconnecting } = useAccount();
   const { error } = useConnect();
-  const { data: signer } = useSigner();
   const { disconnect } = useDisconnect();
 
   const isLoading = isConnecting || isReconnecting;
 
   // memo-ize the context value to prevent unnecessary re-renders
   const value = useMemo(
-    () => ({ address, disconnect, error, isLoading, signer, isConnected }),
-    [address, disconnect, error, isLoading, signer, isConnected],
+    () => ({
+      address,
+      disconnect,
+      error,
+      isLoading,
+      isConnected,
+    }),
+    [address, disconnect, error, isLoading, isConnected],
   );
 
   return (

--- a/examples/react-quickstart/src/globals.d.ts
+++ b/examples/react-quickstart/src/globals.d.ts
@@ -1,5 +1,6 @@
 interface ImportMeta {
   env: {
     VITE_PROJECT_ID: string;
+    VITE_INFURA_ID: string;
   };
 }

--- a/examples/react-quickstart/src/main.tsx
+++ b/examples/react-quickstart/src/main.tsx
@@ -2,9 +2,19 @@ import "./polyfills";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "@rainbow-me/rainbowkit/styles.css";
-import { getDefaultWallets, RainbowKitProvider } from "@rainbow-me/rainbowkit";
-import { configureChains, createClient, WagmiConfig } from "wagmi";
-import { mainnet } from "wagmi/chains";
+import {
+  connectorsForWallets,
+  RainbowKitProvider,
+} from "@rainbow-me/rainbowkit";
+import {
+  coinbaseWallet,
+  metaMaskWallet,
+  rainbowWallet,
+  trustWallet,
+  walletConnectWallet,
+} from "@rainbow-me/rainbowkit/wallets";
+import { createConfig, configureChains, mainnet, WagmiConfig } from "wagmi";
+import { infuraProvider } from "wagmi/providers/infura";
 import { publicProvider } from "wagmi/providers/public";
 import {
   XMTPProvider,
@@ -27,27 +37,39 @@ const contentTypeConfigs = [
   replyContentTypeConfig,
 ];
 
-const { chains, provider, webSocketProvider } = configureChains(
+const { chains, publicClient } = configureChains(
   [mainnet],
-  [publicProvider()],
+  [
+    infuraProvider({ apiKey: import.meta.env.VITE_INFURA_ID }),
+    publicProvider(),
+  ],
 );
 
-const { connectors } = getDefaultWallets({
-  appName: "XMTP React RainbowKit Example",
-  chains,
-  // now required for WalletConnect V2
-  projectId: import.meta.env.VITE_PROJECT_ID,
-});
+const projectId = import.meta.env.VITE_PROJECT_ID;
+const appName = "XMTP React Quickstart";
 
-const wagmiClient = createClient({
+const connectors = connectorsForWallets([
+  {
+    groupName: "Wallets",
+    wallets: [
+      // Alpha order
+      coinbaseWallet({ appName, chains }),
+      metaMaskWallet({ chains, projectId }),
+      rainbowWallet({ chains, projectId }),
+      trustWallet({ projectId, chains }),
+      walletConnectWallet({ chains, projectId }),
+    ],
+  },
+]);
+
+const wagmiConfig = createConfig({
   autoConnect: true,
   connectors,
-  provider,
-  webSocketProvider,
+  publicClient,
 });
 
 createRoot(document.getElementById("root") as HTMLElement).render(
-  <WagmiConfig client={wagmiClient}>
+  <WagmiConfig config={wagmiConfig}>
     <RainbowKitProvider chains={chains}>
       <StrictMode>
         <WalletProvider>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@changesets/cli": "^2.26.2"
   },
   "resolutions": {
-    "@xmtp/xmtp-js": "^10.2.0",
+    "@xmtp/xmtp-js": "^11.1.1",
     "vite": "^4.4.9"
   }
 }

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -73,9 +73,9 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.0.18",
-    "@xmtp/content-type-reaction": "^1.0.1",
-    "@xmtp/content-type-remote-attachment": "^1.0.7",
-    "@xmtp/content-type-reply": "^1.0.0",
+    "@xmtp/content-type-reaction": "^1.1.2",
+    "@xmtp/content-type-remote-attachment": "^1.1.2",
+    "@xmtp/content-type-reply": "^1.1.3",
     "@xmtp/react-sdk": "workspace:*",
     "date-fns": "^2.30.0",
     "react": "^18.2.0",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -72,17 +72,18 @@
     "typedoc": "typedoc"
   },
   "dependencies": {
-    "@xmtp/content-type-reaction": "^1.0.1",
-    "@xmtp/content-type-read-receipt": "^1.0.1",
-    "@xmtp/content-type-remote-attachment": "^1.0.7",
-    "@xmtp/content-type-reply": "^1.0.0",
-    "@xmtp/xmtp-js": "^10.2.1",
+    "@xmtp/content-type-reaction": "^1.1.2",
+    "@xmtp/content-type-read-receipt": "^1.1.3",
+    "@xmtp/content-type-remote-attachment": "^1.1.2",
+    "@xmtp/content-type-reply": "^1.1.3",
+    "@xmtp/xmtp-js": "^11.1.1",
     "async-mutex": "^0.4.0",
     "date-fns": "^2.30.0",
     "dexie": "^3.2.4",
     "dexie-react-hooks": "^1.1.6",
     "react": "^18.2.0",
     "uuid": "^9.0.0",
+    "viem": "^1.12.2",
     "zod": "^3.22.1"
   },
   "devDependencies": {
@@ -96,7 +97,6 @@
     "@xmtp/tsconfig": "workspace:*",
     "eslint": "^8.47.0",
     "eslint-config-xmtp-web": "workspace:*",
-    "ethers": "^6.7.0",
     "fake-indexeddb": "^4.0.2",
     "jsdom": "^21.1.2",
     "prettier": "^3.0.2",
@@ -109,7 +109,7 @@
     "vitest": "^0.34.2"
   },
   "peerDependencies": {
-    "@xmtp/xmtp-js": "^10.2.1",
+    "@xmtp/xmtp-js": "^11.1.1",
     "react": ">=16.14"
   },
   "engines": {

--- a/packages/react-sdk/src/contexts/XMTPContext.tsx
+++ b/packages/react-sdk/src/contexts/XMTPContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useMemo, useState } from "react";
 import type { Client, ContentCodec, Signer } from "@xmtp/xmtp-js";
 import Dexie from "dexie";
+import type { WalletClient } from "viem";
 import type {
   ContentTypeConfiguration,
   ContentTypeMessageProcessors,
@@ -40,11 +41,13 @@ export type XMTPContextValue = {
   /**
    * Set the signer (wallet) to associate with the XMTP client instance
    */
-  setClientSigner: React.Dispatch<React.SetStateAction<Signer | undefined>>;
+  setClientSigner: React.Dispatch<
+    React.SetStateAction<Signer | WalletClient | undefined>
+  >;
   /**
    * The signer (wallet) associated with the XMTP client instance
    */
-  signer?: Signer | null;
+  signer?: Signer | WalletClient | null;
   /**
    * Message content validators for content types
    */
@@ -89,9 +92,9 @@ export const XMTPProvider: React.FC<XMTPProviderProps> = ({
   dbVersion,
 }) => {
   const [client, setClient] = useState<Client | undefined>(initialClient);
-  const [clientSigner, setClientSigner] = useState<Signer | undefined>(
-    undefined,
-  );
+  const [clientSigner, setClientSigner] = useState<
+    Signer | WalletClient | undefined
+  >(undefined);
 
   // combine all message processors
   const processors = useMemo(

--- a/packages/react-sdk/src/helpers/caching/contentTypes/attachment.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/attachment.test.ts
@@ -10,7 +10,6 @@ import {
   RemoteAttachmentCodec,
 } from "@xmtp/content-type-remote-attachment";
 import { Client, ContentTypeText } from "@xmtp/xmtp-js";
-import { Wallet } from "ethers";
 import {
   getAttachment,
   hasAttachment,
@@ -21,8 +20,9 @@ import {
 import { type CachedMessageWithId } from "@/helpers/caching/messages";
 import { getDbInstance } from "@/helpers/caching/db";
 import type { CachedConversationWithId } from "@/helpers/caching/conversations";
+import { createRandomWallet } from "@/helpers/testing";
 
-const testWallet = Wallet.createRandom();
+const testWallet = createRandomWallet();
 const db = getDbInstance({
   contentTypeConfigs: [attachmentContentTypeConfig],
 });
@@ -59,11 +59,11 @@ describe("ContentTypeRemoteAttachment caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
       } satisfies CachedConversationWithId;
       const testMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: {
           filename: "testFilename",
@@ -104,11 +104,11 @@ describe("ContentTypeRemoteAttachment caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
       } satisfies CachedConversationWithId;
       const testMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: "test",
         contentType: ContentTypeText.toString(),
@@ -147,11 +147,11 @@ describe("ContentTypeRemoteAttachment caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
       } satisfies CachedConversationWithId;
       const testMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: {
           contentDigest: "testContentDigest",
@@ -197,11 +197,11 @@ describe("ContentTypeRemoteAttachment caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
       } satisfies CachedConversationWithId;
       const testMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: "test",
         contentType: ContentTypeText.toString(),
@@ -239,7 +239,7 @@ describe("ContentTypeRemoteAttachment caching", () => {
       } satisfies Attachment;
       const testMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: testContent,
         contentType: ContentTypeAttachment.toString(),
@@ -268,7 +268,7 @@ describe("ContentTypeRemoteAttachment caching", () => {
       } satisfies RemoteAttachment;
       const testMessage2 = {
         id: 2,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: testContent2,
         contentType: ContentTypeRemoteAttachment.toString(),
@@ -287,7 +287,7 @@ describe("ContentTypeRemoteAttachment caching", () => {
 
       const testMessage3 = {
         id: 3,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: "foo",
         contentType: ContentTypeText.toString(),
@@ -315,7 +315,7 @@ describe("ContentTypeRemoteAttachment caching", () => {
       } satisfies Attachment;
       const testMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: testContent,
         contentType: ContentTypeAttachment.toString(),
@@ -334,7 +334,7 @@ describe("ContentTypeRemoteAttachment caching", () => {
 
       const testMessage2 = {
         id: 2,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: "foo",
         contentType: ContentTypeText.toString(),

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reaction.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reaction.test.ts
@@ -1,6 +1,5 @@
 import { it, expect, describe, vi, beforeEach } from "vitest";
 import { Client, ContentTypeText } from "@xmtp/xmtp-js";
-import { Wallet } from "ethers";
 import type { Reaction } from "@xmtp/content-type-reaction";
 import {
   ContentTypeReaction,
@@ -21,8 +20,9 @@ import {
 } from "@/helpers/caching/messages";
 import { getDbInstance, clearCache } from "@/helpers/caching/db";
 import type { CachedConversationWithId } from "@/helpers/caching/conversations";
+import { createRandomWallet } from "@/helpers/testing";
 
-const testWallet = Wallet.createRandom();
+const testWallet = createRandomWallet();
 const db = getDbInstance({
   contentTypeConfigs: [reactionContentTypeConfig],
 });
@@ -77,11 +77,11 @@ describe("ContentTypeReaction caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
       } satisfies CachedConversationWithId;
       const testTextMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: "test",
         contentType: ContentTypeText.toString(),
@@ -106,7 +106,7 @@ describe("ContentTypeReaction caching", () => {
 
       const testReactionMessage = {
         id: 2,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: testReactionContent,
         contentType: ContentTypeReaction.toString(),
@@ -148,7 +148,7 @@ describe("ContentTypeReaction caching", () => {
 
       const testReactionMessage2 = {
         id: 3,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: {
           ...testReactionContent,
@@ -192,11 +192,11 @@ describe("ContentTypeReaction caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
       } satisfies CachedConversationWithId;
       const testMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: "test",
         contentType: ContentTypeText.toString(),

--- a/packages/react-sdk/src/helpers/caching/contentTypes/readReceipt.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/readReceipt.test.ts
@@ -1,6 +1,5 @@
 import { it, expect, describe, vi, beforeEach } from "vitest";
 import { Client, ContentTypeText } from "@xmtp/xmtp-js";
-import { Wallet } from "ethers";
 import type { ReadReceipt } from "@xmtp/content-type-read-receipt";
 import {
   ContentTypeReadReceipt,
@@ -18,8 +17,9 @@ import {
   processReadReceipt,
   readReceiptContentTypeConfig,
 } from "@/helpers/caching/contentTypes/readReceipt";
+import { createRandomWallet } from "@/helpers/testing";
 
-const testWallet = Wallet.createRandom();
+const testWallet = createRandomWallet();
 const db = getDbInstance({
   contentTypeConfigs: [readReceiptContentTypeConfig],
 });
@@ -52,27 +52,23 @@ describe("ContentTypeReadReceipt caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
       } satisfies CachedConversationWithId;
 
       await saveConversation(testConversation, db);
 
-      const readReceiptDate = new Date();
-
-      const testReadReceiptContent = {
-        timestamp: readReceiptDate.toString(),
-      } satisfies ReadReceipt;
+      const sentAt = new Date();
 
       const testReadReceiptMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
-        content: testReadReceiptContent,
+        content: {},
         contentType: ContentTypeReadReceipt.toString(),
         isSending: false,
         hasLoadError: false,
         hasSendError: false,
-        sentAt: new Date(),
+        sentAt,
         status: "unprocessed",
         senderAddress: "testWalletAddress",
         uuid: "testUuid1",
@@ -92,7 +88,7 @@ describe("ContentTypeReadReceipt caching", () => {
       });
       expect(persist).not.toHaveBeenCalled();
       expect(updateConversationMetadata).toHaveBeenCalledWith(
-        readReceiptDate.toString(),
+        sentAt.toISOString(),
       );
     });
 
@@ -105,11 +101,11 @@ describe("ContentTypeReadReceipt caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
       } satisfies CachedConversationWithId;
       const testTextMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: "test",
         contentType: ContentTypeText.toString(),
@@ -149,7 +145,7 @@ describe("ContentTypeReadReceipt caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         metadata: {
           readReceipt: readReceiptDate.toISOString(),
         },
@@ -168,7 +164,7 @@ describe("ContentTypeReadReceipt caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
       } satisfies CachedConversationWithId;
       expect(getReadReceipt(testConversation)).toBe(undefined);
     });
@@ -183,7 +179,7 @@ describe("ContentTypeReadReceipt caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         metadata: {
           readReceipt: new Date().toString(),
         },
@@ -200,7 +196,7 @@ describe("ContentTypeReadReceipt caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
       } satisfies CachedConversationWithId;
       expect(hasReadReceipt(testConversation)).toBe(false);
     });

--- a/packages/react-sdk/src/helpers/caching/contentTypes/readReceipt.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/readReceipt.ts
@@ -1,4 +1,3 @@
-import type { ReadReceipt } from "@xmtp/content-type-read-receipt";
 import {
   ReadReceiptCodec,
   ContentTypeReadReceipt,
@@ -39,9 +38,7 @@ export const getReadReceipt = (conversation: CachedConversation) => {
 export const hasReadReceipt = (conversation: CachedConversation) =>
   getReadReceipt(conversation) !== undefined;
 
-const ReadReceiptContentSchema = z.object({
-  timestamp: z.string().refine((value) => !!parseISO(value)),
-});
+const ReadReceiptContentSchema = z.object({}).strict();
 
 /**
  * Validate the content of a read receipt message
@@ -71,10 +68,8 @@ export const processReadReceipt: ContentTypeMessageProcessor = async ({
     conversation &&
     isValidReadReceiptContent(message.content)
   ) {
-    // update message's conversation with the read receipt metadata
-    await updateConversationMetadata(
-      (message.content as ReadReceipt).timestamp,
-    );
+    // update message's conversation with the message timestamp
+    await updateConversationMetadata(message.sentAt.toISOString());
   }
 };
 

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reply.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reply.test.ts
@@ -1,6 +1,5 @@
 import { it, expect, describe, vi, beforeEach } from "vitest";
 import { Client, ContentTypeText } from "@xmtp/xmtp-js";
-import { Wallet } from "ethers";
 import type { Reply } from "@xmtp/content-type-reply";
 import { ContentTypeReply, ReplyCodec } from "@xmtp/content-type-reply";
 import {
@@ -18,8 +17,9 @@ import {
 } from "@/helpers/caching/messages";
 import { getDbInstance, clearCache } from "@/helpers/caching/db";
 import type { CachedConversationWithId } from "@/helpers/caching/conversations";
+import { createRandomWallet } from "@/helpers/testing";
 
-const testWallet = Wallet.createRandom();
+const testWallet = createRandomWallet();
 const db = getDbInstance({
   contentTypeConfigs: [replyContentTypeConfig],
 });
@@ -48,11 +48,11 @@ describe("ContentTypeReply caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
       } satisfies CachedConversationWithId;
       const testTextMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: "test",
         contentType: ContentTypeText.toString(),
@@ -76,7 +76,7 @@ describe("ContentTypeReply caching", () => {
 
       const testReplyMessage = {
         id: 2,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: testReplyContent,
         contentType: ContentTypeReply.toString(),
@@ -128,11 +128,11 @@ describe("ContentTypeReply caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
       } satisfies CachedConversationWithId;
       const testMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: "test",
         contentType: ContentTypeText.toString(),
@@ -165,7 +165,7 @@ describe("ContentTypeReply caching", () => {
     it("should return undefined if the message isn't a processed reply", async () => {
       const testTextMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: "test",
         contentType: ContentTypeText.toString(),
@@ -187,7 +187,7 @@ describe("ContentTypeReply caching", () => {
 
       const testReplyMessage = {
         id: 2,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: {
           content: "test",
@@ -217,7 +217,7 @@ describe("ContentTypeReply caching", () => {
     it("should return empty array if no metadata is present", () => {
       const testTextMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: "test",
         contentType: ContentTypeText.toString(),
@@ -240,7 +240,7 @@ describe("ContentTypeReply caching", () => {
     it("should create multiple replies in message metadata", async () => {
       const testTextMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: "test",
         contentType: ContentTypeText.toString(),

--- a/packages/react-sdk/src/helpers/caching/contentTypes/text.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/text.test.ts
@@ -1,6 +1,5 @@
 import { it, expect, describe, vi } from "vitest";
 import { Client, ContentTypeText } from "@xmtp/xmtp-js";
-import { Wallet } from "ethers";
 import {
   ContentTypeAttachment,
   type Attachment,
@@ -12,8 +11,9 @@ import {
   processText,
   textContentTypeConfig,
 } from "@/helpers/caching/contentTypes/text";
+import { createRandomWallet } from "@/helpers/testing";
 
-const testWallet = Wallet.createRandom();
+const testWallet = createRandomWallet();
 const db = getDbInstance();
 
 describe("ContentTypeText caching", () => {
@@ -35,11 +35,11 @@ describe("ContentTypeText caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
       } satisfies CachedConversationWithId;
       const testMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: "test",
         contentType: ContentTypeText.toString(),
@@ -76,11 +76,11 @@ describe("ContentTypeText caching", () => {
         isReady: false,
         topic: "testTopic",
         peerAddress: "testPeerAddress",
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
       } satisfies CachedConversationWithId;
       const testMessage = {
         id: 1,
-        walletAddress: testWallet.address,
+        walletAddress: testWallet.account.address,
         conversationTopic: "testTopic",
         content: {
           filename: "testFilename",

--- a/packages/react-sdk/src/helpers/caching/conversations.test.ts
+++ b/packages/react-sdk/src/helpers/caching/conversations.test.ts
@@ -1,5 +1,4 @@
 import { it, expect, describe, beforeEach } from "vitest";
-import { Wallet } from "ethers";
 import { Client } from "@xmtp/xmtp-js";
 import { getDbInstance, clearCache } from "@/helpers/caching/db";
 import {
@@ -19,9 +18,11 @@ import type {
   CachedConversationWithId,
 } from "@/helpers/caching/conversations";
 import { adjustDate } from "@/helpers/adjustDate";
+import { createRandomWallet } from "@/helpers/testing";
 
-const testWallet1 = Wallet.createRandom();
-const testWallet2 = Wallet.createRandom();
+const testWallet1 = createRandomWallet();
+const testWallet2 = createRandomWallet();
+
 const db = getDbInstance();
 
 beforeEach(async () => {
@@ -123,7 +124,7 @@ describe("getConversationByTopic", () => {
     const testClient1 = await Client.create(testWallet1, { env: "local" });
     await Client.create(testWallet2, { env: "local" });
     const testConversation = await testClient1.conversations.newConversation(
-      testWallet2.address,
+      testWallet2.account.address,
       undefined,
     );
     const conversation = await getConversationByTopic(
@@ -300,12 +301,12 @@ describe("toCachedConversation", () => {
     const testClient1 = await Client.create(testWallet1, { env: "local" });
     await Client.create(testWallet2, { env: "local" });
     const testConversation = await testClient1.conversations.newConversation(
-      testWallet2.address,
+      testWallet2.account.address,
       undefined,
     );
     const cachedConversation = toCachedConversation(
       testConversation,
-      testWallet1.address,
+      testWallet1.account.address,
     );
     expect(cachedConversation).toEqual({
       context: undefined,
@@ -314,7 +315,7 @@ describe("toCachedConversation", () => {
       peerAddress: testConversation.peerAddress,
       topic: testConversation.topic,
       updatedAt: testConversation.createdAt,
-      walletAddress: testWallet1.address,
+      walletAddress: testWallet1.account.address,
     });
   });
 });

--- a/packages/react-sdk/src/helpers/caching/messages.test.ts
+++ b/packages/react-sdk/src/helpers/caching/messages.test.ts
@@ -1,7 +1,6 @@
 import type { ArgumentsType } from "vitest";
 import { it, expect, describe, beforeEach } from "vitest";
 import { Client, ContentTypeText, DecodedMessage } from "@xmtp/xmtp-js";
-import { Wallet } from "ethers";
 import type { CachedMessage } from "@/helpers/caching/messages";
 import {
   saveMessage,
@@ -27,10 +26,11 @@ import {
 } from "@/helpers/caching/conversations";
 import { adjustDate } from "@/helpers/adjustDate";
 import { textContentTypeConfig } from "@/helpers/caching/contentTypes/text";
+import { createRandomWallet } from "@/helpers/testing";
 
 const db = getDbInstance();
-const testWallet1 = Wallet.createRandom();
-const testWallet2 = Wallet.createRandom();
+const testWallet1 = createRandomWallet();
+const testWallet2 = createRandomWallet();
 
 beforeEach(async () => {
   await clearCache(db);
@@ -41,7 +41,7 @@ describe("toCachedMessage", () => {
     const testClient1 = await Client.create(testWallet1, { env: "local" });
     await Client.create(testWallet2, { env: "local" });
     const testConversation = await testClient1.conversations.newConversation(
-      testWallet2.address,
+      testWallet2.account.address,
       undefined,
     );
     const sentAt = new Date();
@@ -1082,12 +1082,12 @@ describe("processUnprocessedMessages", () => {
       isReady: false,
       topic: "testTopic",
       peerAddress: "testPeerAddress",
-      walletAddress: testWallet1.address,
+      walletAddress: testWallet1.account.address,
     } satisfies CachedConversation;
     const cachedConversation = await saveConversation(testConversation, db);
     const testMessage1 = {
       id: 1,
-      walletAddress: testWallet1.address,
+      walletAddress: testWallet1.account.address,
       conversationTopic: "testTopic",
       content: "test",
       contentType: ContentTypeText.toString(),
@@ -1096,14 +1096,14 @@ describe("processUnprocessedMessages", () => {
       hasSendError: false,
       sentAt,
       status: "unprocessed",
-      senderAddress: testWallet1.address,
+      senderAddress: testWallet1.account.address,
       uuid: "testUuid",
       xmtpID: "testXmtpId",
     } satisfies CachedMessage;
     await saveMessage(testMessage1, db);
     const testMessage2 = {
       id: 1,
-      walletAddress: testWallet1.address,
+      walletAddress: testWallet1.account.address,
       conversationTopic: "testTopic",
       content: "test",
       contentType: ContentTypeText.toString(),
@@ -1112,7 +1112,7 @@ describe("processUnprocessedMessages", () => {
       hasSendError: false,
       sentAt,
       status: "processed",
-      senderAddress: testWallet1.address,
+      senderAddress: testWallet1.account.address,
       uuid: "testUuid",
       xmtpID: "testXmtpId",
     } satisfies CachedMessage;
@@ -1151,7 +1151,7 @@ describe("processUnprocessedMessages", () => {
     const sentAt = adjustDate(createdAt, 1000);
     const testMessage1 = {
       id: 1,
-      walletAddress: testWallet1.address,
+      walletAddress: testWallet1.account.address,
       conversationTopic: "testTopic",
       content: "test",
       contentType: ContentTypeText.toString(),
@@ -1160,7 +1160,7 @@ describe("processUnprocessedMessages", () => {
       hasSendError: false,
       sentAt,
       status: "unprocessed",
-      senderAddress: testWallet1.address,
+      senderAddress: testWallet1.account.address,
       uuid: "testUuid",
       xmtpID: "testXmtpId",
     } satisfies CachedMessage;

--- a/packages/react-sdk/src/helpers/testing.ts
+++ b/packages/react-sdk/src/helpers/testing.ts
@@ -1,0 +1,10 @@
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { createWalletClient, http } from "viem";
+import { mainnet } from "viem/chains";
+
+export const createRandomWallet = () =>
+  createWalletClient({
+    account: privateKeyToAccount(generatePrivateKey()),
+    chain: mainnet,
+    transport: http(),
+  });

--- a/packages/react-sdk/src/hooks/useClient.test.tsx
+++ b/packages/react-sdk/src/hooks/useClient.test.tsx
@@ -1,10 +1,10 @@
 import { it, expect, describe, vi, beforeEach } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { Client } from "@xmtp/xmtp-js";
-import { Wallet } from "ethers";
 import type { PropsWithChildren } from "react";
 import { useClient } from "@/hooks/useClient";
 import { XMTPProvider } from "@/contexts/XMTPContext";
+import { createRandomWallet } from "@/helpers/testing";
 
 const processUnprocessedMessagesMock = vi.hoisted(() => vi.fn());
 
@@ -54,7 +54,7 @@ describe("useClient", () => {
       address: "testWalletAddress",
     };
     const clientCreateSpy = vi.spyOn(Client, "create");
-    const testWallet = Wallet.createRandom();
+    const testWallet = createRandomWallet();
 
     const { result } = renderHook(() => useClient(), {
       wrapper: ({ children }) => (
@@ -76,7 +76,7 @@ describe("useClient", () => {
   });
 
   it("should initialize a client if one is not active", async () => {
-    const testWallet = Wallet.createRandom();
+    const testWallet = createRandomWallet();
     const mockClient = {
       address: "testWalletAddress",
     } as unknown as Client;
@@ -105,7 +105,7 @@ describe("useClient", () => {
   });
 
   it("should throw an error if client initialization fails", async () => {
-    const testWallet = Wallet.createRandom();
+    const testWallet = createRandomWallet();
     const testError = new Error("testError");
     vi.spyOn(Client, "create").mockRejectedValue(testError);
     const onErrorMock = vi.fn();
@@ -126,7 +126,7 @@ describe("useClient", () => {
   });
 
   it("should should call the onError callback if processing unprocessed messages fails", async () => {
-    const testWallet = Wallet.createRandom();
+    const testWallet = createRandomWallet();
     const testError = new Error("testError");
     const mockClient = {
       address: "testWalletAddress",

--- a/packages/react-sdk/src/hooks/useClient.ts
+++ b/packages/react-sdk/src/hooks/useClient.ts
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useRef, useState } from "react";
 import type { ClientOptions, Signer } from "@xmtp/xmtp-js";
 import { Client } from "@xmtp/xmtp-js";
+import type { WalletClient } from "viem";
 import { XMTPContext } from "../contexts/XMTPContext";
 import type { OnError } from "@/sharedTypes";
 import { processUnprocessedMessages } from "@/helpers/caching/messages";
@@ -19,7 +20,7 @@ export type InitializeClientOptions = {
   /**
    * The signer (wallet) to associate with the XMTP client
    */
-  signer?: Signer | null;
+  signer?: Signer | WalletClient | null;
 };
 
 /**

--- a/packages/react-sdk/src/hooks/useSendMessage.test.ts
+++ b/packages/react-sdk/src/hooks/useSendMessage.test.ts
@@ -94,9 +94,6 @@ describe("useSendMessage", () => {
         testConversation,
         testAttachment,
         ContentTypeAttachment,
-        {
-          contentFallback: "test",
-        },
       );
       expect(sentMessage).toEqual({ id: 1 });
     });
@@ -107,7 +104,6 @@ describe("useSendMessage", () => {
       testAttachment,
       ContentTypeAttachment,
       {
-        contentFallback: "test",
         onError: onErrorMock,
         onSuccess: onSuccessMock,
       },

--- a/packages/react-sdk/src/hooks/useStartConversation.test.ts
+++ b/packages/react-sdk/src/hooks/useStartConversation.test.ts
@@ -279,7 +279,7 @@ describe("useStartConversation", () => {
     expect(saveConversationMock).toHaveBeenCalledTimes(1);
     expect(saveConversationMock).toHaveBeenCalledWith(
       toCachedConversation(
-        mockConversation as unknown as ConversationV2,
+        mockConversation as unknown as ConversationV2<string>,
         "testWalletAddress",
       ),
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,10 +19,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adraffy/ens-normalize@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@adraffy/ens-normalize@npm:1.9.2"
-  checksum: a9fdeb9e080774c19e4b7f9f60aa5b37cf23fe0e8fe80284bf8221f7396e9f78642bfd39a09a94a4dc3fb8e70f2ac81545204bdcaf222d93f4c4c2ae1f0dca0b
+"@adraffy/ens-normalize@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@adraffy/ens-normalize@npm:1.9.4"
+  checksum: 7d7fff58ebe2c4961f7e5e61dad123aa6a63fec0df5c84af1fa41079dc05d398599690be4427b3a94d2baa94084544bcfdf2d51cbed7504b9b0583b0960ad550
   languageName: node
   linkType: hard
 
@@ -4241,10 +4241,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/connect-kit-loader@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "@ledgerhq/connect-kit-loader@npm:1.0.2"
-  checksum: 38475ee5a80b733fee571a8e882e7d309e0e28ef4776adb122bb4be010c54ca966c3946c1cbc78ae0d6abec62cd9ea6c7fbe4879041fe43d173bb287362fa34f
+"@ledgerhq/connect-kit-loader@npm:^1.1.0":
+  version: 1.1.2
+  resolution: "@ledgerhq/connect-kit-loader@npm:1.1.2"
+  checksum: 614fdd9ac2363da60af667adcfe4721f863d8ea06ee45a08192a162c28e806dc07491bee4833d14def74de673eac1f1450eaf67e783c8c28da4e0cd095b4474a
   languageName: node
   linkType: hard
 
@@ -4442,6 +4442,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/curves@npm:1.2.0, @noble/curves@npm:~1.2.0":
+  version: 1.2.0
+  resolution: "@noble/curves@npm:1.2.0"
+  dependencies:
+    "@noble/hashes": 1.3.2
+  checksum: bb798d7a66d8e43789e93bc3c2ddff91a1e19fdb79a99b86cd98f1e5eff0ee2024a2672902c2576ef3577b6f282f3b5c778bebd55761ddbb30e36bf275e83dd0
+  languageName: node
+  linkType: hard
+
 "@noble/ed25519@npm:^1.7.0":
   version: 1.7.3
   resolution: "@noble/ed25519@npm:1.7.3"
@@ -4449,10 +4458,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@noble/hashes@npm:1.1.2"
-  checksum: 3c2a8cb7c2e053811032f242155d870c5eb98844d924d69702244d48804cb03b42d4a666c49c2b71164420d8229cb9a6f242b972d50d5bb2f1d673b98b041de2
+"@noble/hashes@npm:1.3.2, @noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.2":
+  version: 1.3.2
+  resolution: "@noble/hashes@npm:1.3.2"
+  checksum: fe23536b436539d13f90e4b9be843cc63b1b17666a07634a2b1259dded6f490be3d050249e6af98076ea8f2ea0d56f578773c2197f2aa0eeaa5fba5bc18ba474
   languageName: node
   linkType: hard
 
@@ -4463,7 +4472,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/secp256k1@npm:1.7.1, @noble/secp256k1@npm:^1.5.2, @noble/secp256k1@npm:^1.6.3, @noble/secp256k1@npm:^1.7.1":
+"@noble/secp256k1@npm:^1.5.2, @noble/secp256k1@npm:^1.6.3, @noble/secp256k1@npm:^1.7.1":
   version: 1.7.1
   resolution: "@noble/secp256k1@npm:1.7.1"
   checksum: d2301f1f7690368d8409a3152450458f27e54df47e3f917292de3de82c298770890c2de7c967d237eff9c95b70af485389a9695f73eb05a43e2bd562d18b18cb
@@ -4590,9 +4599,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rainbow-me/rainbowkit@npm:^0.12.16":
-  version: 0.12.16
-  resolution: "@rainbow-me/rainbowkit@npm:0.12.16"
+"@rainbow-me/rainbowkit@npm:^1.0.11":
+  version: 1.0.11
+  resolution: "@rainbow-me/rainbowkit@npm:1.0.11"
   dependencies:
     "@vanilla-extract/css": 1.9.1
     "@vanilla-extract/dynamic": 2.0.2
@@ -4601,11 +4610,11 @@ __metadata:
     qrcode: 1.5.0
     react-remove-scroll: 2.5.4
   peerDependencies:
-    ethers: ">=5.6.8"
     react: ">=17"
     react-dom: ">=17"
-    wagmi: ">=0.12.18 <1.0.0"
-  checksum: 7008b22ad4b5c9afa8403d1a13c5a62c82db96437537afca5c283796a17af713ee812c87730e7c2004937abe048e68a02aa3bd5bfbd79a6a75a587b552754bbe
+    viem: ~0.3.19 || ^1.0.0
+    wagmi: ~1.0.1 || ~1.1.0 || ~1.2.0 || ~1.3.0 || ~1.4.0
+  checksum: a8d0be75d88ed97694b165ac76408ff8e2721aed6d1fbda101111e2accb674e7c63f2e2dcdae958cf3dda1f269a6d5740a7d0835fcd420dc39703e34c4375f49
   languageName: node
   linkType: hard
 
@@ -4619,33 +4628,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@safe-global/safe-apps-provider@npm:^0.15.2":
-  version: 0.15.2
-  resolution: "@safe-global/safe-apps-provider@npm:0.15.2"
+"@safe-global/safe-apps-provider@npm:^0.17.1":
+  version: 0.17.1
+  resolution: "@safe-global/safe-apps-provider@npm:0.17.1"
   dependencies:
-    "@safe-global/safe-apps-sdk": 7.9.0
+    "@safe-global/safe-apps-sdk": 8.0.0
     events: ^3.3.0
-  checksum: 5d647d105c935f1cb2b349b2dd3f8b590be5b16f5c1e65e4fd3fb8c72e46bfe8e2bb8e4876642511c41c0b3d75ae2f572e55a35066740c04d80c1def02e93e3b
+  checksum: 02f0415a4bb77b82e55f0055be045af715d9c0ea0fa7daa4e0604f40cc2189051d111b8ead67ddab0e99b1e423b444753c11d69bb213d51e459f706d2b430e34
   languageName: node
   linkType: hard
 
-"@safe-global/safe-apps-sdk@npm:7.9.0":
-  version: 7.9.0
-  resolution: "@safe-global/safe-apps-sdk@npm:7.9.0"
+"@safe-global/safe-apps-sdk@npm:8.0.0":
+  version: 8.0.0
+  resolution: "@safe-global/safe-apps-sdk@npm:8.0.0"
   dependencies:
     "@safe-global/safe-gateway-typescript-sdk": ^3.5.3
-    ethers: ^5.7.2
-  checksum: 439cea5e486e85619c78c876bdbb81544d54c47af24e9633b7e0bd49cb0b25d260f02de573e734cd5bf767c8188bc60729880e30c86785c7e7dd22f0dbd5d0dd
+    viem: ^1.0.0
+  checksum: 07295c44afa4d85fbc9419b4baac56b4fb493816d4438d6956842261e0689fdcea639ab86b39ee693c456fddace17b6c556c77a637892634a57de96f6b00b0c3
   languageName: node
   linkType: hard
 
-"@safe-global/safe-apps-sdk@npm:^7.9.0":
-  version: 7.10.0
-  resolution: "@safe-global/safe-apps-sdk@npm:7.10.0"
+"@safe-global/safe-apps-sdk@npm:^8.0.0":
+  version: 8.1.0
+  resolution: "@safe-global/safe-apps-sdk@npm:8.1.0"
   dependencies:
     "@safe-global/safe-gateway-typescript-sdk": ^3.5.3
-    ethers: ^5.7.2
-  checksum: 77ef8769bbb52ad72c63836928514c096ceee42b0e7d1a46f3fc54b291e909f8471a7492295af605d1c8fc1a27ae100d01f705550f0b40375e8f53fd448de83c
+    viem: ^1.0.0
+  checksum: e9d31ed6d9cd2cd9ed71ef5a0e1f6ecfca9f0c62acb9b86a0ddb1b65a609090f2297c4304591ac0518b266a1bcc88d1dad31b0d05e50c7732accccb65adab754
   languageName: node
   linkType: hard
 
@@ -4655,6 +4664,34 @@ __metadata:
   dependencies:
     cross-fetch: ^3.1.5
   checksum: 648bac448935913890fc9b42cb27bec0deac62dce49146f6fd24ca15509987299143c00cffc5f300b8bd85bfa464230751bd1e8cda80f4ef19f67c7485c09534
+  languageName: node
+  linkType: hard
+
+"@scure/base@npm:~1.1.0, @scure/base@npm:~1.1.2":
+  version: 1.1.3
+  resolution: "@scure/base@npm:1.1.3"
+  checksum: 1606ab8a4db898cb3a1ada16c15437c3bce4e25854fadc8eb03ae93cbbbac1ed90655af4b0be3da37e12056fef11c0374499f69b9e658c9e5b7b3e06353c630c
+  languageName: node
+  linkType: hard
+
+"@scure/bip32@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@scure/bip32@npm:1.3.2"
+  dependencies:
+    "@noble/curves": ~1.2.0
+    "@noble/hashes": ~1.3.2
+    "@scure/base": ~1.1.2
+  checksum: c5ae84fae43490853693b481531132b89e056d45c945fc8b92b9d032577f753dfd79c5a7bbcbf0a7f035951006ff0311b6cf7a389e26c9ec6335e42b20c53157
+  languageName: node
+  linkType: hard
+
+"@scure/bip39@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@scure/bip39@npm:1.2.1"
+  dependencies:
+    "@noble/hashes": ~1.3.0
+    "@scure/base": ~1.1.0
+  checksum: c5bd6f1328fdbeae2dcdd891825b1610225310e5e62a4942714db51066866e4f7bef242c7b06a1b9dcc8043a4a13412cf5c5df76d3b10aa9e36b82e9b6e3eeaa
   languageName: node
   linkType: hard
 
@@ -6264,13 +6301,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:18.15.13":
-  version: 18.15.13
-  resolution: "@types/node@npm:18.15.13"
-  checksum: 79cc5a2b5f98e8973061a4260a781425efd39161a0e117a69cd089603964816c1a14025e1387b4590c8e82d05133b7b4154fa53a7dffb3877890a66145e76515
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^12.12.54, @types/node@npm:^12.7.1":
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
@@ -6436,6 +6466,15 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: b4c9b8ad209620c9b21e78314ce4ff07515c0cadab9af101c1651e7bfb992d7fd933bd8b9c99d110738fd6db523ed15f82f29f50b45510288da72e964dedb1a3
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.5.5":
+  version: 8.5.6
+  resolution: "@types/ws@npm:8.5.6"
+  dependencies:
+    "@types/node": "*"
+  checksum: 7addb0c5fa4e7713d5209afb8a90f1852b12c02cb537395adf7a05fbaf21205dc5f7c110fd5ad6f3dbf147112cbff33fb11d8633059cb344f0c14f595b1ea1fb
   languageName: node
   linkType: hard
 
@@ -6858,84 +6897,69 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wagmi/chains@npm:0.2.22":
-  version: 0.2.22
-  resolution: "@wagmi/chains@npm:0.2.22"
-  peerDependencies:
-    typescript: ">=4.9.4"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: a8fdbce18f2ed8cce6c765828b78ef59756e3d4dc858af07f42827e78d8ab5b4ab3da2c79cd7cd3f534a6b27edd5bb5f764e6250394b4ae6aa0a055b7bdc518a
-  languageName: node
-  linkType: hard
-
-"@wagmi/connectors@npm:0.3.22":
-  version: 0.3.22
-  resolution: "@wagmi/connectors@npm:0.3.22"
+"@wagmi/connectors@npm:3.1.2":
+  version: 3.1.2
+  resolution: "@wagmi/connectors@npm:3.1.2"
   dependencies:
     "@coinbase/wallet-sdk": ^3.6.6
-    "@ledgerhq/connect-kit-loader": ^1.0.1
-    "@safe-global/safe-apps-provider": ^0.15.2
-    "@safe-global/safe-apps-sdk": ^7.9.0
-    "@walletconnect/ethereum-provider": 2.8.4
+    "@ledgerhq/connect-kit-loader": ^1.1.0
+    "@safe-global/safe-apps-provider": ^0.17.1
+    "@safe-global/safe-apps-sdk": ^8.0.0
+    "@walletconnect/ethereum-provider": 2.10.1
     "@walletconnect/legacy-provider": ^2.0.0
-    "@walletconnect/modal": ^2.5.4
-    abitype: ^0.3.0
+    "@walletconnect/modal": 2.6.2
+    "@walletconnect/utils": 2.10.1
+    abitype: 0.8.7
     eventemitter3: ^4.0.7
   peerDependencies:
-    "@wagmi/core": ">=0.9.x"
-    ethers: ">=5.5.1 <6"
-    typescript: ">=4.9.4"
+    typescript: ">=5.0.4"
+    viem: ">=0.3.35"
   peerDependenciesMeta:
-    "@wagmi/core":
-      optional: true
     typescript:
       optional: true
-  checksum: 903abcbda11fb68744fcfff1da8d7759d9bd62cf82b898d2df3c0f734ad860963ed782c3f866ef413ccb69c693b66ad212f416611dfc00eae834f4a0c04bd11b
+  checksum: 9e00708bafbd2735dafcadb40360fbbf8a90850f19d79172e7549bb4f9655dcdea20159638e1f0ed20c92beb6beb4fd0168cd946ef1c3fa271a1ed92f4265d5c
   languageName: node
   linkType: hard
 
-"@wagmi/core@npm:0.10.16":
-  version: 0.10.16
-  resolution: "@wagmi/core@npm:0.10.16"
+"@wagmi/core@npm:1.4.2":
+  version: 1.4.2
+  resolution: "@wagmi/core@npm:1.4.2"
   dependencies:
-    "@wagmi/chains": 0.2.22
-    "@wagmi/connectors": 0.3.22
-    abitype: ^0.3.0
+    "@wagmi/connectors": 3.1.2
+    abitype: 0.8.7
     eventemitter3: ^4.0.7
     zustand: ^4.3.1
   peerDependencies:
-    ethers: ">=5.5.1 <6"
-    typescript: ">=4.9.4"
+    typescript: ">=5.0.4"
+    viem: ">=0.3.35"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 12b483e7b172173d8d4f2bd963239018759a8359fb3ea0caead16e624ec302987ba2817708b2f09352fd177f1280d3f49f7d2130dd58592328b599a9303f46ba
+  checksum: 0a349d643153a1b966bf0a4198c1b5a06defdfff9b0686c3ffcd3e514f0301b03a58ee9de09e8e7323a70c5550691170bc296a3023046f8caeaacd2213c9ffe8
   languageName: node
   linkType: hard
 
-"@walletconnect/core@npm:2.8.4":
-  version: 2.8.4
-  resolution: "@walletconnect/core@npm:2.8.4"
+"@walletconnect/core@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@walletconnect/core@npm:2.10.1"
   dependencies:
     "@walletconnect/heartbeat": 1.2.1
     "@walletconnect/jsonrpc-provider": 1.0.13
     "@walletconnect/jsonrpc-types": 1.0.3
     "@walletconnect/jsonrpc-utils": 1.0.8
-    "@walletconnect/jsonrpc-ws-connection": ^1.0.11
+    "@walletconnect/jsonrpc-ws-connection": 1.0.13
     "@walletconnect/keyvaluestorage": ^1.0.2
     "@walletconnect/logger": ^2.0.1
     "@walletconnect/relay-api": ^1.0.9
     "@walletconnect/relay-auth": ^1.0.4
     "@walletconnect/safe-json": ^1.0.2
     "@walletconnect/time": ^1.0.2
-    "@walletconnect/types": 2.8.4
-    "@walletconnect/utils": 2.8.4
+    "@walletconnect/types": 2.10.1
+    "@walletconnect/utils": 2.10.1
     events: ^3.3.0
     lodash.isequal: 4.5.0
     uint8arrays: ^3.1.0
-  checksum: bab21068190e42b56e119a89ca47af341a9ab85026c00a0341d7350ce84eab19f4c5e7074bb7846cb83fddc93f66d66820fe59e356a17de1d169ec31d11402f5
+  checksum: d58ae15c53efe1792da8c7aa1b7ba47efb49807cfe0c73f225d59c5cd847a0e50979ce6965b94915812412deba3e5aa2dca13a02bd41c087e85575e99afad223
   languageName: node
   linkType: hard
 
@@ -6973,25 +6997,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/ethereum-provider@npm:2.8.4":
-  version: 2.8.4
-  resolution: "@walletconnect/ethereum-provider@npm:2.8.4"
+"@walletconnect/ethereum-provider@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@walletconnect/ethereum-provider@npm:2.10.1"
   dependencies:
     "@walletconnect/jsonrpc-http-connection": ^1.0.7
     "@walletconnect/jsonrpc-provider": ^1.0.13
     "@walletconnect/jsonrpc-types": ^1.0.3
     "@walletconnect/jsonrpc-utils": ^1.0.8
-    "@walletconnect/sign-client": 2.8.4
-    "@walletconnect/types": 2.8.4
-    "@walletconnect/universal-provider": 2.8.4
-    "@walletconnect/utils": 2.8.4
+    "@walletconnect/sign-client": 2.10.1
+    "@walletconnect/types": 2.10.1
+    "@walletconnect/universal-provider": 2.10.1
+    "@walletconnect/utils": 2.10.1
     events: ^3.3.0
   peerDependencies:
     "@walletconnect/modal": ">=2"
   peerDependenciesMeta:
     "@walletconnect/modal":
       optional: true
-  checksum: e2323b5d085c1ea4600f230f776420447dd4ef5433b0816199c9394b58a82ccc886beadb8ca8ec9f0169f300b6cfde91bb15046f2748a89406db739b3cb3c657
+  checksum: ec3d88ba101a5d8f193262b5b1e770cccad6457ec56fa1f3d17fa531de4e07e8cf03a1341669122c61956f0d5c3a6eca57d3f12f524e046acddb401cdb76fe7c
   languageName: node
   linkType: hard
 
@@ -7115,16 +7139,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/jsonrpc-ws-connection@npm:^1.0.11":
-  version: 1.0.11
-  resolution: "@walletconnect/jsonrpc-ws-connection@npm:1.0.11"
+"@walletconnect/jsonrpc-ws-connection@npm:1.0.13":
+  version: 1.0.13
+  resolution: "@walletconnect/jsonrpc-ws-connection@npm:1.0.13"
   dependencies:
     "@walletconnect/jsonrpc-utils": ^1.0.6
     "@walletconnect/safe-json": ^1.0.2
     events: ^3.3.0
     tslib: 1.14.1
     ws: ^7.5.1
-  checksum: 69fcc5ecb6eafd697fb88e22e6b7a2fd24d06129860feb6bcb5f702062233ebf5aef8b86a8502c67158f48370b98d0f5dffd930a0e5f6944752eb6a3c37a40cb
+  checksum: f2253b17564f7622e69b1252830f05efdf7f4d58b120adb3a3e950c2087845171c912307c39948d0b869aa8610688b83f54f54de4657091f7431aea95a59f8b9
   languageName: node
   linkType: hard
 
@@ -7226,35 +7250,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/modal-core@npm:2.5.9":
-  version: 2.5.9
-  resolution: "@walletconnect/modal-core@npm:2.5.9"
+"@walletconnect/modal-core@npm:2.6.2":
+  version: 2.6.2
+  resolution: "@walletconnect/modal-core@npm:2.6.2"
   dependencies:
-    buffer: 6.0.3
-    valtio: 1.10.6
-  checksum: dfcb0b7a50febafe08fd80fec2b31b86722a27aedad8ee0656af895e2c8b1a2c8a91c7bb5f968bea5b8de9ab7fc908c6f52cef194f949e37da597acd0f1a263b
+    valtio: 1.11.2
+  checksum: 94daceba50c323b06ecbeac2968d9f0972f327359c6118887c6526cd64006249b12f64322d71bc6c4a2b928436ecc89cf3d3af706511fcdc264c1f4b34a2dd5d
   languageName: node
   linkType: hard
 
-"@walletconnect/modal-ui@npm:2.5.9":
-  version: 2.5.9
-  resolution: "@walletconnect/modal-ui@npm:2.5.9"
+"@walletconnect/modal-ui@npm:2.6.2":
+  version: 2.6.2
+  resolution: "@walletconnect/modal-ui@npm:2.6.2"
   dependencies:
-    "@walletconnect/modal-core": 2.5.9
-    lit: 2.7.5
+    "@walletconnect/modal-core": 2.6.2
+    lit: 2.8.0
     motion: 10.16.2
     qrcode: 1.5.3
-  checksum: c0050715734b532f75b81c3abb75c6cce513b1481c9cec66f648aa698ddd3af4ec70978a0976b06843229e6f7ea14cc927432dc66cfe53967db7d96c9437f692
+  checksum: cd1ec0205eb491e529670599d3dd26f6782d7c5a99d5594bf6949a8c760c1c5f4eb6ed72b8662450774fe4e2dd47678f2c05145c8f2494bd7153446ddf4bd7ed
   languageName: node
   linkType: hard
 
-"@walletconnect/modal@npm:^2.5.4":
-  version: 2.5.9
-  resolution: "@walletconnect/modal@npm:2.5.9"
+"@walletconnect/modal@npm:2.6.2":
+  version: 2.6.2
+  resolution: "@walletconnect/modal@npm:2.6.2"
   dependencies:
-    "@walletconnect/modal-core": 2.5.9
-    "@walletconnect/modal-ui": 2.5.9
-  checksum: ba52f4210c238644a2c4d6fbfc1692d7f49e4fa4a85e793aa79c299e9e4d16c0555fcf08bb94726186256aec1e43abb3d7297a61020abe7211f6faac1163dddd
+    "@walletconnect/modal-core": 2.6.2
+    "@walletconnect/modal-ui": 2.6.2
+  checksum: 68b354d49960b96d22de0e47a3801df27c01a3e96ec5fbde3ca6df1344ca2b20668b0c4d58fe1803f5670ac7b7b4c6f5b7b405e354f5f9eaff5cca147c13de9c
   languageName: node
   linkType: hard
 
@@ -7312,20 +7335,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/sign-client@npm:2.8.4":
-  version: 2.8.4
-  resolution: "@walletconnect/sign-client@npm:2.8.4"
+"@walletconnect/sign-client@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@walletconnect/sign-client@npm:2.10.1"
   dependencies:
-    "@walletconnect/core": 2.8.4
+    "@walletconnect/core": 2.10.1
     "@walletconnect/events": ^1.0.1
     "@walletconnect/heartbeat": 1.2.1
     "@walletconnect/jsonrpc-utils": 1.0.8
     "@walletconnect/logger": ^2.0.1
     "@walletconnect/time": ^1.0.2
-    "@walletconnect/types": 2.8.4
-    "@walletconnect/utils": 2.8.4
+    "@walletconnect/types": 2.10.1
+    "@walletconnect/utils": 2.10.1
     events: ^3.3.0
-  checksum: b04bf20a85d1bee5675a6827cd2781d7a88852986ef9d770e53cd2ef5852487b2b026acf7a6648c4e471210b6639e227c7f20c2b94c6cb087acab0072fa6ba4d
+  checksum: dbdced8dece73b20ae73df9c0cf0d9e3eee753f6c81e264c87583ca60d1d13d4f7d61944e4b22d1f70c5f32424fd842a7de778838aa7d0ae27195976a86e102f
   languageName: node
   linkType: hard
 
@@ -7338,9 +7361,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/types@npm:2.8.4":
-  version: 2.8.4
-  resolution: "@walletconnect/types@npm:2.8.4"
+"@walletconnect/types@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@walletconnect/types@npm:2.10.1"
   dependencies:
     "@walletconnect/events": ^1.0.1
     "@walletconnect/heartbeat": 1.2.1
@@ -7348,30 +7371,30 @@ __metadata:
     "@walletconnect/keyvaluestorage": ^1.0.2
     "@walletconnect/logger": ^2.0.1
     events: ^3.3.0
-  checksum: fafe2105ff040fdb22125f1f9ae378dbf12dd92ec228ea12ef1da2b2705c260eda1b51a1256132847f7f5e1f8cbfade417b435c9cfc2efd7ebcc537d33b7a3e3
+  checksum: b663a236404bb423d3cc5cde656794ce42132f09193da5a51dac815d844f78eebb29c7275ebe10f6134492db21386ffd81b66ce42992332847b72c9128f74990
   languageName: node
   linkType: hard
 
-"@walletconnect/universal-provider@npm:2.8.4":
-  version: 2.8.4
-  resolution: "@walletconnect/universal-provider@npm:2.8.4"
+"@walletconnect/universal-provider@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@walletconnect/universal-provider@npm:2.10.1"
   dependencies:
     "@walletconnect/jsonrpc-http-connection": ^1.0.7
     "@walletconnect/jsonrpc-provider": 1.0.13
     "@walletconnect/jsonrpc-types": ^1.0.2
     "@walletconnect/jsonrpc-utils": ^1.0.7
     "@walletconnect/logger": ^2.0.1
-    "@walletconnect/sign-client": 2.8.4
-    "@walletconnect/types": 2.8.4
-    "@walletconnect/utils": 2.8.4
+    "@walletconnect/sign-client": 2.10.1
+    "@walletconnect/types": 2.10.1
+    "@walletconnect/utils": 2.10.1
     events: ^3.3.0
-  checksum: 51c7271a540045018f7bad25aa80c1bb48e7ac6863a1ed7129759bba7a9dd1d1162cd91062cf3058497d1537b4dbbb1b69091640c769f5787f6cd368749d4b88
+  checksum: a33ad597a7601157cd96bceb7637c3463a5df981e5548c5343ab84f92c542bd7cae577fb2884d549164c9ad8262b097dc5fc0bc7fd9a515ee7c3f30b271cb034
   languageName: node
   linkType: hard
 
-"@walletconnect/utils@npm:2.8.4":
-  version: 2.8.4
-  resolution: "@walletconnect/utils@npm:2.8.4"
+"@walletconnect/utils@npm:2.10.1":
+  version: 2.10.1
+  resolution: "@walletconnect/utils@npm:2.10.1"
   dependencies:
     "@stablelib/chacha20poly1305": 1.0.1
     "@stablelib/hkdf": 1.0.1
@@ -7381,13 +7404,13 @@ __metadata:
     "@walletconnect/relay-api": ^1.0.9
     "@walletconnect/safe-json": ^1.0.2
     "@walletconnect/time": ^1.0.2
-    "@walletconnect/types": 2.8.4
+    "@walletconnect/types": 2.10.1
     "@walletconnect/window-getters": ^1.0.1
     "@walletconnect/window-metadata": ^1.0.1
     detect-browser: 5.3.0
     query-string: 7.1.3
     uint8arrays: ^3.1.0
-  checksum: afd538be7517b6df8d13d3c1ab6b3fef85ac574c0c5d681c589a8dae5c6d50295af32d8aa213a6aad61da995b663245666f5ad53f132e37f1f85de83fd42ca7e
+  checksum: 150d1a3c75ce0736ffc8ed8a844e3dc63476e556f7f308154ee6bc9d99e08907bc11a504b7ce3889951293b48d9eef4e32b84de1c7f27b7a84e6731a7bb65189
   languageName: node
   linkType: hard
 
@@ -7410,67 +7433,55 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-reaction@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@xmtp/content-type-reaction@npm:1.0.1"
+"@xmtp/content-type-reaction@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@xmtp/content-type-reaction@npm:1.1.2"
   dependencies:
-    "@xmtp/xmtp-js": ^9.1.7
+    "@xmtp/xmtp-js": ^11.1.1
   peerDependencies:
-    "@xmtp/xmtp-js": ^9.1.7
-  checksum: 2318f79a7906a89fb75fb7e0db4588d78e604acda634cc219119afa566fb2fadc182ee1fcfa6b63f3c42b90dc07991fe3fde37b97758246bfeb934bf00fc9f72
+    "@xmtp/xmtp-js": ^11.1.1
+  checksum: 604fa0f64d14a9a26a98afb88d71cf291df87160955725d6763863290e45f9a7cda18740fd3867e5b65d0634a49e8130b877bc3329f89e6f7659127b7f5a1f24
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-read-receipt@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@xmtp/content-type-read-receipt@npm:1.0.1"
+"@xmtp/content-type-read-receipt@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@xmtp/content-type-read-receipt@npm:1.1.3"
   dependencies:
     "@xmtp/proto": ^3.26.0
-    "@xmtp/xmtp-js": ^9.2.0
+    "@xmtp/xmtp-js": ^11.1.1
   peerDependencies:
-    "@xmtp/xmtp-js": ^9.2.0
-  checksum: 106445a2fd5ce6c6535abb646fefaf912f4ef434abe5226e6395fc41571e92863c8854ece8c619eccfce785ae3305e07e3f56b71350fff9d0ab874ebe6d46d07
+    "@xmtp/xmtp-js": ^11.1.1
+  checksum: d3a797acd4c65030c495ecc39972d00ce6c9d8a1d2483a297002f1962463cd55cbffe80e8de0ebb27d1128f9f395cea9e2ab03e0e5d798e7ceefc2dade660838
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-remote-attachment@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "@xmtp/content-type-remote-attachment@npm:1.0.7"
+"@xmtp/content-type-remote-attachment@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@xmtp/content-type-remote-attachment@npm:1.1.2"
   dependencies:
     "@noble/secp256k1": ^1.7.1
-    "@xmtp/proto": ^3.25.0
-    "@xmtp/xmtp-js": ^9.1.6
+    "@xmtp/proto": ^3.27.0
+    "@xmtp/xmtp-js": ^11.1.1
   peerDependencies:
-    "@xmtp/xmtp-js": ^9.1.6
-  checksum: ab7638f0634754f849be9162d16ae819f6a329418727a63b807d492f65a6c9c37c062e9c8cb0bd6aedf34960bd188a091f64bb1332c489f40f525e2dde627df2
+    "@xmtp/xmtp-js": ^11.1.1
+  checksum: 7d20edf0252caaaecac1aa2fdc811e494a86d7788b90f423e2487e0164669f3174dca12869cfde46112662a400e6feed454a63bbdaef427ed50e31fad7b4307e
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-reply@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@xmtp/content-type-reply@npm:1.0.0"
+"@xmtp/content-type-reply@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@xmtp/content-type-reply@npm:1.1.3"
   dependencies:
     "@xmtp/proto": ^3.26.0
-    "@xmtp/xmtp-js": ^9.2.0
+    "@xmtp/xmtp-js": ^11.1.1
   peerDependencies:
-    "@xmtp/xmtp-js": ^9.2.0
-  checksum: 7f204eab598d55a755d88328cd957aa713dad7281437ced0113a29801f67d759e8d2ac1852e69874b7ab72bc9f29e2a10a52cf105ae1a8aab5126ad0ce0a0758
+    "@xmtp/xmtp-js": ^11.1.1
+  checksum: 916b51e25dfd1ead7ba9e42c4126722a458435d016875048516ed0322ea0a0d7645c788ca4b338a3e1a078156571dd00fb9f665931554204f851061493f3899d
   languageName: node
   linkType: hard
 
-"@xmtp/proto@npm:^3.24.0":
-  version: 3.25.0
-  resolution: "@xmtp/proto@npm:3.25.0"
-  dependencies:
-    long: ^5.2.0
-    protobufjs: ^7.0.0
-    rxjs: ^7.8.0
-    undici: ^5.8.1
-  checksum: 9673abcbe5b53252d12216bd24743c1176e4c7578c0214333668009fa1ef98dd9a422c388122096d5a175fc886651b87107d35d7cb836e6d647c9923b290fd77
-  languageName: node
-  linkType: hard
-
-"@xmtp/proto@npm:^3.25.0, @xmtp/proto@npm:^3.26.0":
+"@xmtp/proto@npm:^3.26.0":
   version: 3.26.0
   resolution: "@xmtp/proto@npm:3.26.0"
   dependencies:
@@ -7479,6 +7490,30 @@ __metadata:
     rxjs: ^7.8.0
     undici: ^5.8.1
   checksum: 2d29c5fdcaa3332577fac20a65a7ca837e937b8aab5c6bb2f20a198e5d07c9d76b534676fcc98b5375ef00f5f9f54f858d55524b3da40b8fe1db4225e1c4fdd7
+  languageName: node
+  linkType: hard
+
+"@xmtp/proto@npm:^3.27.0":
+  version: 3.27.0
+  resolution: "@xmtp/proto@npm:3.27.0"
+  dependencies:
+    long: ^5.2.0
+    protobufjs: ^7.0.0
+    rxjs: ^7.8.0
+    undici: ^5.8.1
+  checksum: 99d2c2cc90de4cb1d125a88bbd9434ab3a7db6b0709687ffc7d9665a2a2acd1f7c88b05b24281f75e2a11ae36b89350f51fb466cac6c30547a3201bc229dfb1a
+  languageName: node
+  linkType: hard
+
+"@xmtp/proto@npm:^3.28.0-beta.1":
+  version: 3.28.0-beta.1
+  resolution: "@xmtp/proto@npm:3.28.0-beta.1"
+  dependencies:
+    long: ^5.2.0
+    protobufjs: ^7.0.0
+    rxjs: ^7.8.0
+    undici: ^5.8.1
+  checksum: d222356318e72359bf54aea0fb967c3beeac94c82649c2e9c8cdb0a5a01ecf5c1264af1f1a4d2eeffb0d8b05561f0e3ee9b1ee44fa5742edfb0e1b288af8b96d
   languageName: node
   linkType: hard
 
@@ -7500,9 +7535,9 @@ __metadata:
     "@types/react": ^18.2.20
     "@types/react-dom": ^18.2.7
     "@vitejs/plugin-react": ^4.0.4
-    "@xmtp/content-type-reaction": ^1.0.1
-    "@xmtp/content-type-remote-attachment": ^1.0.7
-    "@xmtp/content-type-reply": ^1.0.0
+    "@xmtp/content-type-reaction": ^1.1.2
+    "@xmtp/content-type-remote-attachment": ^1.1.2
+    "@xmtp/content-type-reply": ^1.1.3
     "@xmtp/react-sdk": "workspace:*"
     "@xmtp/tsconfig": "workspace:*"
     date-fns: ^2.30.0
@@ -7533,25 +7568,25 @@ __metadata:
   resolution: "@xmtp/react-quickstart-example@workspace:examples/react-quickstart"
   dependencies:
     "@heroicons/react": ^2.0.18
-    "@rainbow-me/rainbowkit": ^0.12.16
+    "@rainbow-me/rainbowkit": ^1.0.11
     "@types/react": ^18.2.20
     "@types/react-dom": ^18.2.7
     "@vitejs/plugin-react": ^4.0.4
-    "@xmtp/content-type-remote-attachment": ^1.0.7
+    "@xmtp/content-type-remote-attachment": ^1.1.2
     "@xmtp/react-components": "workspace:*"
     "@xmtp/react-sdk": "workspace:*"
     "@xmtp/tsconfig": "workspace:*"
     autoprefixer: ^10.4.15
     eslint: ^8.47.0
     eslint-config-xmtp-web: "workspace:*"
-    ethers: 5.7.2
     postcss: ^8.4.25
     postcss-preset-env: ^8.5.1
     react: ^18.2.0
     react-dom: ^18.2.0
     typescript: ^5.1.6
+    viem: ^1.12.2
     vite: ^4.4.9
-    wagmi: ^0.12.18
+    wagmi: ^1.4.2
   languageName: unknown
   linkType: soft
 
@@ -7566,19 +7601,18 @@ __metadata:
     "@types/uuid": ^9.0.2
     "@vitejs/plugin-react": ^4.0.4
     "@vitest/coverage-v8": ^0.34.2
-    "@xmtp/content-type-reaction": ^1.0.1
-    "@xmtp/content-type-read-receipt": ^1.0.1
-    "@xmtp/content-type-remote-attachment": ^1.0.7
-    "@xmtp/content-type-reply": ^1.0.0
+    "@xmtp/content-type-reaction": ^1.1.2
+    "@xmtp/content-type-read-receipt": ^1.1.3
+    "@xmtp/content-type-remote-attachment": ^1.1.2
+    "@xmtp/content-type-reply": ^1.1.3
     "@xmtp/tsconfig": "workspace:*"
-    "@xmtp/xmtp-js": ^10.2.1
+    "@xmtp/xmtp-js": ^11.1.1
     async-mutex: ^0.4.0
     date-fns: ^2.30.0
     dexie: ^3.2.4
     dexie-react-hooks: ^1.1.6
     eslint: ^8.47.0
     eslint-config-xmtp-web: "workspace:*"
-    ethers: ^6.7.0
     fake-indexeddb: ^4.0.2
     jsdom: ^21.1.2
     prettier: ^3.0.2
@@ -7588,12 +7622,13 @@ __metadata:
     typedoc: ^0.24.8
     typescript: ^5.1.6
     uuid: ^9.0.0
+    viem: ^1.12.2
     vite: ^4.4.9
     vite-tsconfig-paths: ^4.2.0
     vitest: ^0.34.2
     zod: ^3.22.1
   peerDependencies:
-    "@xmtp/xmtp-js": ^10.2.1
+    "@xmtp/xmtp-js": ^11.1.1
     react: ">=16.14"
   languageName: unknown
   linkType: soft
@@ -7604,17 +7639,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/xmtp-js@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "@xmtp/xmtp-js@npm:10.2.0"
+"@xmtp/xmtp-js@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "@xmtp/xmtp-js@npm:11.1.1"
   dependencies:
     "@noble/secp256k1": ^1.5.2
-    "@xmtp/proto": ^3.24.0
+    "@xmtp/proto": ^3.28.0-beta.1
     async-mutex: ^0.4.0
     elliptic: ^6.5.4
     ethers: ^5.5.3
     long: ^5.2.0
-  checksum: 116a34b4232c817494f292082d24c5ab84ec4536203b950e7cc079a4acbe5b43da594a6e52bffacab51cea3a4b00ac006dec9f32aba69919acf5098c5b22cf2a
+  checksum: 208c5606c1d207d8141867067708b872a495cad27ca3327f0797479ac76f3e6c5d2c163bf6c2416cf7b06a33bcb3e00ee51077d902236339e4387bc2113bfa90
   languageName: node
   linkType: hard
 
@@ -7655,16 +7690,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abitype@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "abitype@npm:0.3.0"
+"abitype@npm:0.8.7":
+  version: 0.8.7
+  resolution: "abitype@npm:0.8.7"
   peerDependencies:
-    typescript: ">=4.9.4"
-    zod: ">=3.19.1"
+    typescript: ">=5.0.4"
+    zod: ^3 >=3.19.1
   peerDependenciesMeta:
     zod:
       optional: true
-  checksum: d7f604d917d0ffddc0a7865c24db78585d257202500a70b99c63da659fe299148778fcb78b31e9dbc2d213d69475880702cb05be22eaa0a49e22c73672dd97e1
+  checksum: 4351466808969bcc73e5c535c3d96bb687ee2be0bccd48eba024c47e6cc248f0c8bd368f9e42dab35d39923e63b1349ade470f72812de27127968caf1a1426c9
+  languageName: node
+  linkType: hard
+
+"abitype@npm:0.9.8":
+  version: 0.9.8
+  resolution: "abitype@npm:0.9.8"
+  peerDependencies:
+    typescript: ">=5.0.4"
+    zod: ^3 >=3.19.1
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+    zod:
+      optional: true
+  checksum: d7d887f29d6821e3f7a400de9620511b80ead3f85c5c87308aaec97965d3493e6687ed816e88722b4f512249bd66dee9e69231b49af0e1db8f69400a62c87cf6
   languageName: node
   linkType: hard
 
@@ -7749,13 +7799,6 @@ __metadata:
   version: 3.0.0
   resolution: "aes-js@npm:3.0.0"
   checksum: 251e26d533cd1a915b44896b17d5ed68c24a02484cfdd2e74ec700a309267db96651ea4eb657bf20aac32a3baa61f6e34edf8e2fec2de440a655da9942d334b8
-  languageName: node
-  linkType: hard
-
-"aes-js@npm:4.0.0-beta.5":
-  version: 4.0.0-beta.5
-  resolution: "aes-js@npm:4.0.0-beta.5"
-  checksum: cc2ea969d77df939c32057f7e361b6530aa6cb93cb10617a17a45cd164e6d761002f031ff6330af3e67e58b1f0a3a8fd0b63a720afd591a653b02f649470e15b
   languageName: node
   linkType: hard
 
@@ -8581,16 +8624,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:6.0.3, buffer@npm:^6.0.3, buffer@npm:~6.0.3":
-  version: 6.0.3
-  resolution: "buffer@npm:6.0.3"
-  dependencies:
-    base64-js: ^1.3.1
-    ieee754: ^1.2.1
-  checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
-  languageName: node
-  linkType: hard
-
 "buffer@npm:^5.5.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
@@ -8598,6 +8631,16 @@ __metadata:
     base64-js: ^1.3.1
     ieee754: ^1.1.13
   checksum: e2cf8429e1c4c7b8cbd30834ac09bd61da46ce35f5c22a78e6c2f04497d6d25541b16881e30a019c6fd3154150650ccee27a308eff3e26229d788bbdeb08ab84
+  languageName: node
+  linkType: hard
+
+"buffer@npm:^6.0.3, buffer@npm:~6.0.3":
+  version: 6.0.3
+  resolution: "buffer@npm:6.0.3"
+  dependencies:
+    base64-js: ^1.3.1
+    ieee754: ^1.2.1
+  checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
   languageName: node
   linkType: hard
 
@@ -10884,7 +10927,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:5.7.2, ethers@npm:^5.5.3, ethers@npm:^5.7.2":
+"ethers@npm:^5.5.3":
   version: 5.7.2
   resolution: "ethers@npm:5.7.2"
   dependencies:
@@ -10919,21 +10962,6 @@ __metadata:
     "@ethersproject/web": 5.7.1
     "@ethersproject/wordlists": 5.7.0
   checksum: b7c08cf3e257185a7946117dbbf764433b7ba0e77c27298dec6088b3bc871aff711462b0621930c56880ff0a7ceb8b1d3a361ffa259f93377b48e34107f62553
-  languageName: node
-  linkType: hard
-
-"ethers@npm:^6.7.0":
-  version: 6.7.0
-  resolution: "ethers@npm:6.7.0"
-  dependencies:
-    "@adraffy/ens-normalize": 1.9.2
-    "@noble/hashes": 1.1.2
-    "@noble/secp256k1": 1.7.1
-    "@types/node": 18.15.13
-    aes-js: 4.0.0-beta.5
-    tslib: 2.4.0
-    ws: 8.5.0
-  checksum: 6d2ea085010da1c34750ce4a00a94d2abbeb3ababb23aa754acc7772682f145e8c1b3862d3b5374e1c182aee569c80ea48191107d469a4de3b0dd6af3d9ce6db
   languageName: node
   linkType: hard
 
@@ -12629,6 +12657,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isomorphic-ws@npm:5.0.0":
+  version: 5.0.0
+  resolution: "isomorphic-ws@npm:5.0.0"
+  peerDependencies:
+    ws: "*"
+  checksum: e20eb2aee09ba96247465fda40c6d22c1153394c0144fa34fe6609f341af4c8c564f60ea3ba762335a7a9c306809349f9b863c8beedf2beea09b299834ad5398
+  languageName: node
+  linkType: hard
+
 "isomorphic-ws@npm:^4.0.1":
   version: 4.0.1
   resolution: "isomorphic-ws@npm:4.0.1"
@@ -13201,14 +13238,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lit@npm:2.7.5":
-  version: 2.7.5
-  resolution: "lit@npm:2.7.5"
+"lit-html@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "lit-html@npm:2.8.0"
+  dependencies:
+    "@types/trusted-types": ^2.0.2
+  checksum: 2d70df07248bcb2f502a3afb1e91d260735024fa669669ffb1417575aa39c3092779725ac1b90f5f39e4ce78c63f431f51176bc67f532389f0285a6991573255
+  languageName: node
+  linkType: hard
+
+"lit@npm:2.8.0":
+  version: 2.8.0
+  resolution: "lit@npm:2.8.0"
   dependencies:
     "@lit/reactive-element": ^1.6.0
     lit-element: ^3.3.0
-    lit-html: ^2.7.0
-  checksum: 61a3f87c57136618f47a30b36cdfb592fcba42dcfbdb104d2b5ca291148c2d9a32fcb713bb91090bd08d6897a00e73f8425da6e3626aa080eaf410a32397ae69
+    lit-html: ^2.8.0
+  checksum: 2480e733f7d022d3ecba91abc58a20968f0ca8f5fa30b3341ecf4bcf4845e674ad27b721a5ae53529cafc6ca603c015b80d0979ceb7a711e268ef20bb6bc7527
   languageName: node
   linkType: hard
 
@@ -17533,13 +17579,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.4.0":
-  version: 2.4.0
-  resolution: "tslib@npm:2.4.0"
-  checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
-  languageName: node
-  linkType: hard
-
 "tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0":
   version: 2.5.0
   resolution: "tslib@npm:2.5.0"
@@ -18237,18 +18276,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"valtio@npm:1.10.6":
-  version: 1.10.6
-  resolution: "valtio@npm:1.10.6"
+"valtio@npm:1.11.2":
+  version: 1.11.2
+  resolution: "valtio@npm:1.11.2"
   dependencies:
     proxy-compare: 2.5.1
     use-sync-external-store: 1.2.0
   peerDependencies:
+    "@types/react": ">=16.8"
     react: ">=16.8"
   peerDependenciesMeta:
+    "@types/react":
+      optional: true
     react:
       optional: true
-  checksum: 0e738aa204c479c8f8c89c0a7478d6784c28ddd712be529fdc5c421d3ec28157fec2fb022a75cd4f45b8c4b470fbc64a27032adba6ed9936bdad989256222adf
+  checksum: cce2d9212aac9fc4bdeba2d381188cc831cfe8d2d03039024cfcd58ba1801f2a5b14d01c2bb21a2c9f12046d2ede64f1dd887175185f39bee553677a35592c30
   languageName: node
   linkType: hard
 
@@ -18256,6 +18298,28 @@ __metadata:
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: ae0123222c6df65b437669d63dfa8c36cee20a504101b2fcd97b8bf76f91259c17f9f2b4d70a1e3c6bbcee7f51b28392833adb6b2770b23b01abec84e369660b
+  languageName: node
+  linkType: hard
+
+"viem@npm:^1.0.0, viem@npm:^1.12.2":
+  version: 1.12.2
+  resolution: "viem@npm:1.12.2"
+  dependencies:
+    "@adraffy/ens-normalize": 1.9.4
+    "@noble/curves": 1.2.0
+    "@noble/hashes": 1.3.2
+    "@scure/bip32": 1.3.2
+    "@scure/bip39": 1.2.1
+    "@types/ws": ^8.5.5
+    abitype: 0.9.8
+    isomorphic-ws: 5.0.0
+    ws: 8.13.0
+  peerDependencies:
+    typescript: ">=5.0.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 558bc2b46afb177a34356f3cc8e6e444f4a6bf4d8aa15658f95eecc1bb42bbc09f240a1fd8eae98fa4973c3a1dc34f0492034b4b4d182f65b2dadf80167c8cea
   languageName: node
   linkType: hard
 
@@ -18414,24 +18478,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wagmi@npm:^0.12.18":
-  version: 0.12.18
-  resolution: "wagmi@npm:0.12.18"
+"wagmi@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "wagmi@npm:1.4.2"
   dependencies:
     "@tanstack/query-sync-storage-persister": ^4.27.1
     "@tanstack/react-query": ^4.28.0
     "@tanstack/react-query-persist-client": ^4.28.0
-    "@wagmi/core": 0.10.16
-    abitype: ^0.3.0
+    "@wagmi/core": 1.4.2
+    abitype: 0.8.7
     use-sync-external-store: ^1.2.0
   peerDependencies:
-    ethers: ">=5.5.1 <6"
     react: ">=17.0.0"
-    typescript: ">=4.9.4"
+    typescript: ">=5.0.4"
+    viem: ">=0.3.35"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: c730db300e71946deb4e184b187ef82a9f3d34d4d5dabbfdb9104471eae713e510d8f9595468675179c8a59f8ef0423505e80f50561673fb2809a3496909971e
+  checksum: c663eb342d2dac5117bdac0cd7c9d93cb4f95254997348ac17cfc39424faffb71a8dfeae8900e1e9ab1a0b7b4c843d85288f9b2c0880131bb5d7e52d78de635d
   languageName: node
   linkType: hard
 
@@ -18774,18 +18838,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.5.0":
-  version: 8.5.0
-  resolution: "ws@npm:8.5.0"
+"ws@npm:8.13.0, ws@npm:^8.13.0, ws@npm:^8.2.3":
+  version: 8.13.0
+  resolution: "ws@npm:8.13.0"
   peerDependencies:
     bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
+    utf-8-validate: ">=5.0.2"
   peerDependenciesMeta:
     bufferutil:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 76f2f90e40344bf18fd544194e7067812fb1372b2a37865678d8f12afe4b478ff2ebc0c7c0aff82cd5e6b66fc43d889eec0f1865c2365d8f7a66d92da7744a77
+  checksum: 53e991bbf928faf5dc6efac9b8eb9ab6497c69feeb94f963d648b7a3530a720b19ec2e0ec037344257e05a4f35bd9ad04d9de6f289615ffb133282031b18c61c
   languageName: node
   linkType: hard
 
@@ -18810,21 +18874,6 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: c3c100a181b731f40b7f2fddf004aa023f79d64f489706a28bc23ff88e87f6a64b3c6651fbec3a84a53960b75159574d7a7385709847a62ddb7ad6af76f49138
-  languageName: node
-  linkType: hard
-
-"ws@npm:^8.13.0, ws@npm:^8.2.3":
-  version: 8.13.0
-  resolution: "ws@npm:8.13.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 53e991bbf928faf5dc6efac9b8eb9ab6497c69feeb94f963d648b7a3530a720b19ec2e0ec037344257e05a4f35bd9ad04d9de6f289615ffb133282031b18c61c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In this PR:

* Upgrade JS SDK to v11
* Upgrade all standards-track content types
* Replace `ethers` with `viem`
* Update read receipt processor for updated content type
* Update client signer type

This PR can be reviewed by commit.