### PR TITLE
Fix client initialization with keys

### DIFF
--- a/.changeset/dirty-eagles-rhyme.md
+++ b/.changeset/dirty-eagles-rhyme.md
@@ -1,0 +1,13 @@
+---
+"@xmtp/react-sdk": major
+---
+
+*** BREAKING CHANGES
+
+* Remove `signer` and `setClientSigner` from `XMTPContext`
+
+*** OTHER CHANGES
+
+* Fix client initialization when using only keys
+* Add test for client initialization with keys
+

--- a/.changeset/dirty-eagles-rhyme.md
+++ b/.changeset/dirty-eagles-rhyme.md
@@ -10,4 +10,5 @@
 
 * Fix client initialization when using only keys
 * Add test for client initialization with keys
+* Upgraded dependencies
 

--- a/packages/react-sdk/src/contexts/XMTPContext.tsx
+++ b/packages/react-sdk/src/contexts/XMTPContext.tsx
@@ -1,7 +1,6 @@
 import { createContext, useMemo, useState } from "react";
-import type { Client, ContentCodec, Signer } from "@xmtp/xmtp-js";
+import type { Client, ContentCodec } from "@xmtp/xmtp-js";
 import Dexie from "dexie";
-import type { WalletClient } from "viem";
 import type {
   ContentTypeConfiguration,
   ContentTypeMessageProcessors,
@@ -39,16 +38,6 @@ export type XMTPContextValue = {
    */
   setClient: React.Dispatch<React.SetStateAction<Client | undefined>>;
   /**
-   * Set the signer (wallet) to associate with the XMTP client instance
-   */
-  setClientSigner: React.Dispatch<
-    React.SetStateAction<Signer | WalletClient | undefined>
-  >;
-  /**
-   * The signer (wallet) associated with the XMTP client instance
-   */
-  signer?: Signer | WalletClient | null;
-  /**
    * Message content validators for content types
    */
   validators: ContentTypeMessageValidators;
@@ -62,7 +51,6 @@ export const XMTPContext = createContext<XMTPContextValue>({
   namespaces: {},
   processors: {},
   setClient: () => {},
-  setClientSigner: () => {},
   validators: {},
 });
 
@@ -92,9 +80,6 @@ export const XMTPProvider: React.FC<XMTPProviderProps> = ({
   dbVersion,
 }) => {
   const [client, setClient] = useState<Client | undefined>(initialClient);
-  const [clientSigner, setClientSigner] = useState<
-    Signer | WalletClient | undefined
-  >(undefined);
 
   // combine all message processors
   const processors = useMemo(
@@ -140,11 +125,9 @@ export const XMTPProvider: React.FC<XMTPProviderProps> = ({
       namespaces,
       processors,
       setClient,
-      setClientSigner,
-      signer: clientSigner,
       validators,
     }),
-    [client, clientSigner, codecs, db, namespaces, processors, validators],
+    [client, codecs, db, namespaces, processors, validators],
   );
 
   return <XMTPContext.Provider value={value}>{children}</XMTPContext.Provider>;


### PR DESCRIPTION
In this PR:

* Fix client initialization when using only keys
* Add test for client initialization with keys
* Remove `signer` and `setClientSigner` from `XMTPContext`

It's not necessary to store the client signer in the XMTP context as this will be accessible within code context or through libraries like `viem`, `wagmi`, or `ethers`.