### PR TITLE
Refactor message syncing in `useMessages` hook

### DIFF
--- a/.changeset/kind-mayflies-bake.md
+++ b/.changeset/kind-mayflies-bake.md
@@ -1,0 +1,8 @@
+---
+"@xmtp/react-sdk": minor
+---
+
+* Added `lastSyncedAt` property to cached conversations to track when a conversation's messages were last synced
+* When loading new messages, use the `lastSyncedAt` time if it comes before the last message
+* When an inactive tab becomes active again, the `useMessages` hook will re-sync the conversation messages from the network
+* Added a new `disableAutoSync` option to `useMessages` hook to disable automatic syncing when a tab becomes active

--- a/packages/react-sdk/src/helpers/caching/conversations.ts
+++ b/packages/react-sdk/src/helpers/caching/conversations.ts
@@ -9,6 +9,7 @@ export type CachedConversation<M = ContentTypeMetadata> = {
   createdAt: Date;
   id?: number;
   isReady: boolean;
+  lastSyncedAt?: Date;
   metadata?: M;
   peerAddress: string;
   topic: string;
@@ -106,7 +107,10 @@ export const getConversationByTopic = async (
 export const updateConversation = async (
   topic: string,
   update: Partial<
-    Pick<CachedConversation, "updatedAt" | "isReady" | "metadata">
+    Pick<
+      CachedConversation,
+      "updatedAt" | "isReady" | "metadata" | "lastSyncedAt"
+    >
   >,
   db: Dexie,
 ) => {

--- a/packages/react-sdk/src/hooks/useMessages.ts
+++ b/packages/react-sdk/src/hooks/useMessages.ts
@@ -121,7 +121,7 @@ export const useMessages = (
         await updateConversation(conversation.topic, { isReady: true });
       }
 
-      // set the last synced time to the time of the most recent message
+      // update the conversation's last synced time
       await updateConversation(conversation.topic, {
         lastSyncedAt,
       });

--- a/packages/react-sdk/src/hooks/useMessages.ts
+++ b/packages/react-sdk/src/hooks/useMessages.ts
@@ -1,11 +1,11 @@
 import { SortDirection, type DecodedMessage } from "@xmtp/xmtp-js";
 import { useCallback, useEffect, useRef, useState } from "react";
 import min from "date-fns/min";
+import subSeconds from "date-fns/subSeconds";
 import type { OnError } from "../sharedTypes";
 import { useCachedMessages } from "./useCachedMessages";
 import type { CachedMessageWithId } from "@/helpers/caching/messages";
 import { toCachedMessage } from "@/helpers/caching/messages";
-import { adjustDate } from "@/helpers/adjustDate";
 import { getConversationByTopic } from "@/helpers/caching/conversations";
 import type { CachedConversation } from "@/helpers/caching/conversations";
 import { useClient } from "./useClient";
@@ -85,8 +85,8 @@ export const useMessages = (
         conversation.lastSyncedAt ?? Date.now(),
         conversation.updatedAt,
       ]);
-      // only fetch messages after the most recent message in the conversation
-      startTime = adjustDate(syncFrom, 1);
+      // account for clock drift
+      startTime = subSeconds(syncFrom, 10);
     }
 
     try {


### PR DESCRIPTION
in this PR:

* added `lastSyncedAt` property to cached conversations
* when loading new messages, use the `lastSyncedAt` time if it comes before the last message
* when an inactive tab becomes active again, re-sync the conversation messages from the network
* added new `disableAutoSync` option to `useMessages` hook to disable automatic syncing when a tab becomes active

these changes should fix cases where streamed messages are missed and not re-synced from the network.

resolves #91 