### PR TITLE
Add reaction timestamp, sort reactions by it

### DIFF
--- a/.changeset/fresh-olives-vanish.md
+++ b/.changeset/fresh-olives-vanish.md
@@ -1,0 +1,7 @@
+---
+"@xmtp/react-sdk": minor
+---
+
+* Added `sentAt` field to cached reactions to track when a reaction was made
+* Updated `getReactionsByXmtpID` to return reactions sorted by `sentAt`
+* Updated `useReactions` hook to return reactions sorted by `sentAt`

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reaction.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reaction.test.ts
@@ -43,27 +43,39 @@ describe("ContentTypeReaction caching", () => {
 
   describe("saveReaction", () => {
     it("should save a reaction to the cache", async () => {
+      const firstSentAt = new Date();
       const testReaction = {
         content: "test",
         referenceXmtpID: "testXmtpId",
         schema: "custom",
         senderAddress: "testWalletAddress",
+        sentAt: firstSentAt,
         xmtpID: "testXmtpId",
       } satisfies CachedReaction;
 
       const reactionId = await saveReaction(testReaction, db);
       expect(reactionId).toEqual(1);
 
+      const testReactions = await getReactionsByXmtpID("testXmtpId", db);
+      expect(testReactions.length).toEqual(1);
+      expect(testReactions[0].sentAt).toEqual(firstSentAt);
+
+      const secondSentAt = new Date();
       const testReaction2 = {
         content: "test",
         referenceXmtpID: "testXmtpId",
         schema: "custom",
         senderAddress: "testWalletAddress",
+        sentAt: secondSentAt,
         xmtpID: "testXmtpId",
       } satisfies CachedReaction;
 
       const reactionId2 = await saveReaction(testReaction2, db);
       expect(reactionId2).toEqual(1);
+
+      const testReactions2 = await getReactionsByXmtpID("testXmtpId", db);
+      expect(testReactions2.length).toEqual(1);
+      expect(testReactions2[0].sentAt).toEqual(secondSentAt);
     });
   });
 

--- a/packages/react-sdk/src/hooks/useReactions.ts
+++ b/packages/react-sdk/src/hooks/useReactions.ts
@@ -17,7 +17,7 @@ export const useReactions = (message?: CachedMessage) => {
         return await reactionsTable
           .where("referenceXmtpID")
           .equals(message.xmtpID)
-          .toArray();
+          .sortBy("sentAt");
       } catch {
         return [];
       }


### PR DESCRIPTION
in this PR:

* added `sentAt` field to cached reaction to track when a reaction was made
* updated `getReactionsByXmtpID` to return reactions sorted by `sentAt`
* updated `useReactions` hook to return reactions sorted by `sentAt`