### PR TITLE
Upgrade standards-track content types

### DIFF
--- a/.changeset/stupid-socks-return.md
+++ b/.changeset/stupid-socks-return.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-sdk": patch
+---
+
+- Upgraded standards-track content types

--- a/examples/react-quickstart/package.json
+++ b/examples/react-quickstart/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@heroicons/react": "^2.0.18",
     "@rainbow-me/rainbowkit": "^1.0.11",
-    "@xmtp/content-type-remote-attachment": "^1.1.2",
+    "@xmtp/content-type-remote-attachment": "^1.1.3",
     "@xmtp/react-components": "workspace:*",
     "@xmtp/react-sdk": "workspace:*",
     "react": "^18.2.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -74,8 +74,8 @@
   "dependencies": {
     "@heroicons/react": "^2.0.18",
     "@xmtp/content-type-reaction": "^1.1.2",
-    "@xmtp/content-type-remote-attachment": "^1.1.2",
-    "@xmtp/content-type-reply": "^1.1.3",
+    "@xmtp/content-type-remote-attachment": "^1.1.3",
+    "@xmtp/content-type-reply": "^1.1.4",
     "@xmtp/react-sdk": "workspace:*",
     "date-fns": "^2.30.0",
     "react": "^18.2.0",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -73,9 +73,9 @@
   },
   "dependencies": {
     "@xmtp/content-type-reaction": "^1.1.2",
-    "@xmtp/content-type-read-receipt": "^1.1.3",
-    "@xmtp/content-type-remote-attachment": "^1.1.2",
-    "@xmtp/content-type-reply": "^1.1.3",
+    "@xmtp/content-type-read-receipt": "^1.1.4",
+    "@xmtp/content-type-remote-attachment": "^1.1.3",
+    "@xmtp/content-type-reply": "^1.1.4",
     "@xmtp/xmtp-js": "^11.1.1",
     "async-mutex": "^0.4.0",
     "date-fns": "^2.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7974,64 +7974,52 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-read-receipt@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "@xmtp/content-type-read-receipt@npm:1.1.3"
+"@xmtp/content-type-read-receipt@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@xmtp/content-type-read-receipt@npm:1.1.4"
   dependencies:
-    "@xmtp/proto": ^3.26.0
+    "@xmtp/proto": ^3.28.0
     "@xmtp/xmtp-js": ^11.1.1
   peerDependencies:
     "@xmtp/xmtp-js": ^11.1.1
-  checksum: d3a797acd4c65030c495ecc39972d00ce6c9d8a1d2483a297002f1962463cd55cbffe80e8de0ebb27d1128f9f395cea9e2ab03e0e5d798e7ceefc2dade660838
+  checksum: fa36a551e3f044003d1239f2069f4c9e9338fb509761d17dd3d6df3de5fd17e989379caf8d4b964e79bb4669d49c908624c3cf9e7c1e9273b4307a671842a98d
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-remote-attachment@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@xmtp/content-type-remote-attachment@npm:1.1.2"
+"@xmtp/content-type-remote-attachment@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@xmtp/content-type-remote-attachment@npm:1.1.3"
   dependencies:
     "@noble/secp256k1": ^1.7.1
-    "@xmtp/proto": ^3.27.0
+    "@xmtp/proto": ^3.28.0
     "@xmtp/xmtp-js": ^11.1.1
   peerDependencies:
     "@xmtp/xmtp-js": ^11.1.1
-  checksum: 7d20edf0252caaaecac1aa2fdc811e494a86d7788b90f423e2487e0164669f3174dca12869cfde46112662a400e6feed454a63bbdaef427ed50e31fad7b4307e
+  checksum: e42e2043b4fccd581a3fa3f19ee713c156ed81d5ceb602b6ca5b8011742f91c0f299f63d8e528a9d247f35c1d1af0859529ad08f8cc1b7db2a728e123f672a21
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-reply@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "@xmtp/content-type-reply@npm:1.1.3"
+"@xmtp/content-type-reply@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@xmtp/content-type-reply@npm:1.1.4"
   dependencies:
-    "@xmtp/proto": ^3.26.0
+    "@xmtp/proto": ^3.28.0
     "@xmtp/xmtp-js": ^11.1.1
   peerDependencies:
     "@xmtp/xmtp-js": ^11.1.1
-  checksum: 916b51e25dfd1ead7ba9e42c4126722a458435d016875048516ed0322ea0a0d7645c788ca4b338a3e1a078156571dd00fb9f665931554204f851061493f3899d
+  checksum: f13d4c33b8dfd59170210aa0d6d156b7d381e950ca100507f85c9ebab0895dcd97b6f5ed334db0ca100bc3ef754667fbd4287c8b671bc40c8dd6e6e1b0412f05
   languageName: node
   linkType: hard
 
-"@xmtp/proto@npm:^3.26.0":
-  version: 3.26.0
-  resolution: "@xmtp/proto@npm:3.26.0"
+"@xmtp/proto@npm:^3.28.0":
+  version: 3.28.0
+  resolution: "@xmtp/proto@npm:3.28.0"
   dependencies:
     long: ^5.2.0
     protobufjs: ^7.0.0
     rxjs: ^7.8.0
     undici: ^5.8.1
-  checksum: 2d29c5fdcaa3332577fac20a65a7ca837e937b8aab5c6bb2f20a198e5d07c9d76b534676fcc98b5375ef00f5f9f54f858d55524b3da40b8fe1db4225e1c4fdd7
-  languageName: node
-  linkType: hard
-
-"@xmtp/proto@npm:^3.27.0":
-  version: 3.27.0
-  resolution: "@xmtp/proto@npm:3.27.0"
-  dependencies:
-    long: ^5.2.0
-    protobufjs: ^7.0.0
-    rxjs: ^7.8.0
-    undici: ^5.8.1
-  checksum: 99d2c2cc90de4cb1d125a88bbd9434ab3a7db6b0709687ffc7d9665a2a2acd1f7c88b05b24281f75e2a11ae36b89350f51fb466cac6c30547a3201bc229dfb1a
+  checksum: 517016070568082ac8d6bfb1ebd51980b4119c2d05700b00b71b7af7be642cf798aa74e94a234ae692ff857ccd1505270685a7d826e5ee6b1fbb83e8167864d1
   languageName: node
   linkType: hard
 
@@ -8066,8 +8054,8 @@ __metadata:
     "@types/react-dom": ^18.2.8
     "@vitejs/plugin-react": ^4.1.0
     "@xmtp/content-type-reaction": ^1.1.2
-    "@xmtp/content-type-remote-attachment": ^1.1.2
-    "@xmtp/content-type-reply": ^1.1.3
+    "@xmtp/content-type-remote-attachment": ^1.1.3
+    "@xmtp/content-type-reply": ^1.1.4
     "@xmtp/react-sdk": "workspace:*"
     "@xmtp/tsconfig": "workspace:*"
     date-fns: ^2.30.0
@@ -8102,7 +8090,7 @@ __metadata:
     "@types/react": ^18.2.20
     "@types/react-dom": ^18.2.8
     "@vitejs/plugin-react": ^4.1.0
-    "@xmtp/content-type-remote-attachment": ^1.1.2
+    "@xmtp/content-type-remote-attachment": ^1.1.3
     "@xmtp/react-components": "workspace:*"
     "@xmtp/react-sdk": "workspace:*"
     "@xmtp/tsconfig": "workspace:*"
@@ -8132,9 +8120,9 @@ __metadata:
     "@vitejs/plugin-react": ^4.1.0
     "@vitest/coverage-v8": ^0.34.5
     "@xmtp/content-type-reaction": ^1.1.2
-    "@xmtp/content-type-read-receipt": ^1.1.3
-    "@xmtp/content-type-remote-attachment": ^1.1.2
-    "@xmtp/content-type-reply": ^1.1.3
+    "@xmtp/content-type-read-receipt": ^1.1.4
+    "@xmtp/content-type-remote-attachment": ^1.1.3
+    "@xmtp/content-type-reply": ^1.1.4
     "@xmtp/tsconfig": "workspace:*"
     "@xmtp/xmtp-js": ^11.1.1
     async-mutex: ^0.4.0


### PR DESCRIPTION
these upgrades should fix issues with missing exports from `@xmtp/proto`.