### PR TITLE
Refactor message processing, sending, configs

### DIFF
--- a/.changeset/small-frogs-whisper.md
+++ b/.changeset/small-frogs-whisper.md
@@ -1,0 +1,7 @@
+---
+"@xmtp/react-sdk": minor
+---
+
+- Added `replies` table to local cache
+- Updated reply helpers to work with new `replies` table
+- Added `useReplies` hook that return replies to a specified message

--- a/.changeset/small-frogs-whisper.md
+++ b/.changeset/small-frogs-whisper.md
@@ -1,7 +1,13 @@
 ---
-"@xmtp/react-sdk": minor
+"@xmtp/react-sdk": major
 ---
 
-- Added `replies` table to local cache
-- Updated reply helpers to work with new `replies` table
-- Added `useReplies` hook that return replies to a specified message
+* Upgraded JS SDK to `11.2.0`
+* Refactored message sending to prepare messages prior to sending
+* Refactored message processing to always cache messages
+* Added `contentTypes` to content type config
+* Removed unnecessary processors from some content type configs
+* Added guard to prevent sending messages that haven't been fully processed
+* Added `replies` table to local cache
+* Updated reply helpers to work with new `replies` table
+* Added `useReplies` hook that return replies to a specified message

--- a/examples/react-quickstart/package.json
+++ b/examples/react-quickstart/package.json
@@ -18,6 +18,8 @@
   "dependencies": {
     "@heroicons/react": "^2.0.18",
     "@rainbow-me/rainbowkit": "^1.0.11",
+    "@xmtp/content-type-reaction": "^1.1.3",
+    "@xmtp/content-type-read-receipt": "^1.1.5",
     "@xmtp/content-type-remote-attachment": "^1.1.4",
     "@xmtp/react-components": "workspace:*",
     "@xmtp/react-sdk": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@changesets/cli": "^2.26.2"
   },
   "resolutions": {
-    "@xmtp/xmtp-js": "^11.1.1",
+    "@xmtp/xmtp-js": "^11.2.0",
     "vite": "^4.4.9"
   }
 }

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -76,7 +76,7 @@
     "@xmtp/content-type-read-receipt": "^1.1.5",
     "@xmtp/content-type-remote-attachment": "^1.1.4",
     "@xmtp/content-type-reply": "^1.1.5",
-    "@xmtp/xmtp-js": "^11.1.2",
+    "@xmtp/xmtp-js": "^11.2.0",
     "async-mutex": "^0.4.0",
     "date-fns": "^2.30.0",
     "dexie": "^3.2.4",
@@ -109,7 +109,7 @@
     "vitest": "^0.34.2"
   },
   "peerDependencies": {
-    "@xmtp/xmtp-js": "^11.1.1",
+    "@xmtp/xmtp-js": "^11.2.0",
     "react": ">=16.14"
   },
   "engines": {

--- a/packages/react-sdk/src/helpers/caching/contentTypes/attachment.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/attachment.ts
@@ -8,13 +8,9 @@ import {
   ContentTypeRemoteAttachment,
   RemoteAttachmentCodec,
 } from "@xmtp/content-type-remote-attachment";
-import { ContentTypeId } from "@xmtp/xmtp-js";
 import { z } from "zod";
 import type Dexie from "dexie";
-import type {
-  ContentTypeConfiguration,
-  ContentTypeMessageProcessor,
-} from "../db";
+import type { ContentTypeConfiguration } from "../db";
 import { updateMessageMetadata, type CachedMessage } from "../messages";
 
 const NAMESPACE = "attachment";
@@ -97,25 +93,6 @@ const isValidAttachmentContent = (content: unknown) => {
   return success;
 };
 
-/**
- * Process an attachment message
- *
- * Saves the message to the cache.
- */
-export const processAttachment: ContentTypeMessageProcessor = async ({
-  message,
-  persist,
-}) => {
-  const contentType = ContentTypeId.fromString(message.contentType);
-  if (
-    ContentTypeAttachment.sameAs(contentType) &&
-    isValidAttachmentContent(message.content)
-  ) {
-    // save message to cache
-    await persist();
-  }
-};
-
 const RemoveAttachmentContentSchema = z.object({
   url: z.string(),
   contentDigest: z.string(),
@@ -138,32 +115,13 @@ const isValidRemoveAttachmentContent = (content: unknown) => {
   return success;
 };
 
-/**
- * Process a remote attachment message
- *
- * Saves the message to the cache.
- */
-export const processRemoteAttachment: ContentTypeMessageProcessor = async ({
-  message,
-  persist,
-}) => {
-  const contentType = ContentTypeId.fromString(message.contentType);
-  if (
-    ContentTypeRemoteAttachment.sameAs(contentType) &&
-    isValidRemoveAttachmentContent(message.content)
-  ) {
-    // save message to cache
-    await persist();
-  }
-};
-
 export const attachmentContentTypeConfig: ContentTypeConfiguration = {
   codecs: [new AttachmentCodec(), new RemoteAttachmentCodec()],
+  contentTypes: [
+    ContentTypeAttachment.toString(),
+    ContentTypeRemoteAttachment.toString(),
+  ],
   namespace: NAMESPACE,
-  processors: {
-    [ContentTypeAttachment.toString()]: [processAttachment],
-    [ContentTypeRemoteAttachment.toString()]: [processRemoteAttachment],
-  },
   validators: {
     [ContentTypeAttachment.toString()]: isValidAttachmentContent,
     [ContentTypeRemoteAttachment.toString()]: isValidRemoveAttachmentContent,

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reaction.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reaction.test.ts
@@ -27,7 +27,7 @@ const db = getDbInstance({
   contentTypeConfigs: [reactionContentTypeConfig],
 });
 
-describe("ContentTypeReaction caching", () => {
+describe("ContentTypeReaction", () => {
   beforeEach(async () => {
     await clearCache(db);
   });
@@ -132,18 +132,15 @@ describe("ContentTypeReaction caching", () => {
         xmtpID: "testXmtpId2",
       } satisfies CachedMessageWithId<Reaction>;
 
-      const persist = vi.fn();
       const updateConversationMetadata = vi.fn();
       await processReaction({
         client: testClient,
         conversation: testConversation,
         db,
         message: testReactionMessage,
-        persist,
         updateConversationMetadata,
         processors: reactionContentTypeConfig.processors,
       });
-      expect(persist).not.toHaveBeenCalled();
 
       const reactions = await getReactionsByXmtpID("testXmtpId1", db);
       expect(reactions.length).toEqual(1);
@@ -182,11 +179,9 @@ describe("ContentTypeReaction caching", () => {
         conversation: testConversation,
         db,
         message: testReactionMessage2,
-        persist,
         updateConversationMetadata,
         processors: reactionContentTypeConfig.processors,
       });
-      expect(persist).not.toHaveBeenCalled();
 
       const reactions2 = await getReactionsByXmtpID("testXmtpId1", db);
       expect(reactions2.length).toEqual(0);
@@ -222,18 +217,15 @@ describe("ContentTypeReaction caching", () => {
         xmtpID: "testXmtpId",
       } satisfies CachedMessageWithId;
 
-      const persist = vi.fn();
       const updateConversationMetadata = vi.fn();
       await processReaction({
         client: testClient,
         conversation: testConversation,
         db,
         message: testMessage,
-        persist,
         updateConversationMetadata,
         processors: reactionContentTypeConfig.processors,
       });
-      expect(persist).not.toHaveBeenCalled();
       const reactionsTable = db.table("reactions") as CachedReactionsTable;
       const allReactions = await reactionsTable.toArray();
       expect(allReactions.length).toEqual(0);

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reaction.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reaction.ts
@@ -210,6 +210,7 @@ export const processReaction: ContentTypeMessageProcessor = async ({
 
 export const reactionContentTypeConfig: ContentTypeConfiguration = {
   codecs: [new ReactionCodec()],
+  contentTypes: [ContentTypeReaction.toString()],
   namespace: NAMESPACE,
   processors: {
     [ContentTypeReaction.toString()]: [processReaction],

--- a/packages/react-sdk/src/helpers/caching/contentTypes/readReceipt.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/readReceipt.test.ts
@@ -25,7 +25,7 @@ const db = getDbInstance({
   contentTypeConfigs: [readReceiptContentTypeConfig],
 });
 
-describe("ContentTypeReadReceipt caching", () => {
+describe("ContentTypeReadReceipt", () => {
   beforeEach(async () => {
     await clearCache(db);
   });
@@ -76,18 +76,15 @@ describe("ContentTypeReadReceipt caching", () => {
         xmtpID: "testXmtpId1",
       } satisfies CachedMessageWithId<ReadReceipt>;
 
-      const persist = vi.fn();
       const updateConversationMetadata = vi.fn();
       await processReadReceipt({
         client: testClient,
         conversation: testConversation,
         db,
         message: testReadReceiptMessage,
-        persist,
         updateConversationMetadata,
         processors: readReceiptContentTypeConfig.processors,
       });
-      expect(persist).not.toHaveBeenCalled();
       expect(updateConversationMetadata).toHaveBeenCalledWith({
         incoming: sentAt.toISOString(),
       });
@@ -113,11 +110,9 @@ describe("ContentTypeReadReceipt caching", () => {
         conversation: testConversation,
         db,
         message: testReadReceiptMessage2,
-        persist,
         updateConversationMetadata,
         processors: readReceiptContentTypeConfig.processors,
       });
-      expect(persist).not.toHaveBeenCalled();
       expect(updateConversationMetadata).toHaveBeenCalledWith({
         outgoing: sentAt.toISOString(),
       });
@@ -138,7 +133,6 @@ describe("ContentTypeReadReceipt caching", () => {
       await saveConversation(testConversation, db);
 
       const sentAt = new Date();
-      const persist = vi.fn();
       const updateConversationMetadata = vi.fn();
 
       const testReadReceiptMessage = {
@@ -162,11 +156,9 @@ describe("ContentTypeReadReceipt caching", () => {
         conversation: testConversation,
         db,
         message: testReadReceiptMessage,
-        persist,
         updateConversationMetadata,
         processors: readReceiptContentTypeConfig.processors,
       });
-      expect(persist).not.toHaveBeenCalled();
       expect(updateConversationMetadata).toHaveBeenCalledWith({
         incoming: sentAt.toISOString(),
       });
@@ -192,11 +184,9 @@ describe("ContentTypeReadReceipt caching", () => {
         conversation: testConversation,
         db,
         message: testReadReceiptMessage2,
-        persist,
         updateConversationMetadata,
         processors: readReceiptContentTypeConfig.processors,
       });
-      expect(persist).not.toHaveBeenCalled();
       expect(updateConversationMetadata).toHaveBeenCalledWith({
         incoming: sentAt.toISOString(),
       });
@@ -229,18 +219,15 @@ describe("ContentTypeReadReceipt caching", () => {
         xmtpID: "testXmtpId1",
       } satisfies CachedMessageWithId;
 
-      const persist = vi.fn();
       const updateConversationMetadata = vi.fn();
       await processReadReceipt({
         client: testClient,
         conversation: testConversation,
         db,
         message: testMessage,
-        persist,
         updateConversationMetadata,
         processors: readReceiptContentTypeConfig.processors,
       });
-      expect(persist).not.toHaveBeenCalled();
       expect(updateConversationMetadata).not.toHaveBeenCalled();
     });
 
@@ -271,18 +258,15 @@ describe("ContentTypeReadReceipt caching", () => {
         xmtpID: "testXmtpId1",
       } satisfies CachedMessageWithId;
 
-      const persist = vi.fn();
       const updateConversationMetadata = vi.fn();
       await processReadReceipt({
         client: testClient,
         conversation: testConversation,
         db,
         message: testTextMessage,
-        persist,
         updateConversationMetadata,
         processors: readReceiptContentTypeConfig.processors,
       });
-      expect(persist).not.toHaveBeenCalled();
       expect(updateConversationMetadata).not.toHaveBeenCalled();
     });
   });

--- a/packages/react-sdk/src/helpers/caching/contentTypes/readReceipt.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/readReceipt.ts
@@ -119,6 +119,7 @@ export const processReadReceipt: ContentTypeMessageProcessor = async ({
 
 export const readReceiptContentTypeConfig: ContentTypeConfiguration = {
   codecs: [new ReadReceiptCodec()],
+  contentTypes: [ContentTypeReadReceipt.toString()],
   namespace: NAMESPACE,
   processors: {
     [ContentTypeReadReceipt.toString()]: [processReadReceipt],

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reply.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reply.ts
@@ -1,24 +1,34 @@
 import type { Reply } from "@xmtp/content-type-reply";
 import { ReplyCodec, ContentTypeReply } from "@xmtp/content-type-reply";
 import { ContentTypeId } from "@xmtp/xmtp-js";
-import type { Dexie } from "dexie";
+import type { Dexie, Table } from "dexie";
 import { z } from "zod";
-import type { CachedMessage } from "@/helpers/caching/messages";
+import type {
+  CachedMessage,
+  CachedMessagesTable,
+} from "@/helpers/caching/messages";
 import type {
   ContentTypeConfiguration,
   ContentTypeMessageProcessor,
 } from "../db";
-import { getMessageByXmtpID, updateMessageMetadata } from "../messages";
+import { getMessageByXmtpID } from "../messages";
 
 const NAMESPACE = "replies";
 
-export type CachedRepliesMetadata = string[];
+export type CachedReply = {
+  id?: number;
+  referenceXmtpID: Reply["reference"];
+  xmtpID: string;
+};
+
+export type CachedReplyWithId = CachedReply & {
+  id: number;
+};
+
+export type CachedRepliesTable = Table<CachedReply, number>;
 
 /**
- * Add a reply to the metadata of a cached message
- *
- * Replies are stored as an array of XMTP message IDs in the metadata of
- * the original message.
+ * Add a reply to the cache
  *
  * @param xmtpID XMTP message ID of the original message
  * @param replyXmtpID XMTP message ID of the reply message
@@ -29,37 +39,60 @@ export const addReply = async (
   replyXmtpID: string,
   db: Dexie,
 ) => {
-  const message = await getMessageByXmtpID(xmtpID, db);
-  if (message) {
-    const replies = (message.metadata?.[NAMESPACE] ??
-      []) as CachedRepliesMetadata;
-    const exists = replies.some((reply) => reply === replyXmtpID);
-    if (!exists) {
-      replies.push(replyXmtpID);
-      await updateMessageMetadata(message, NAMESPACE, replies, db);
-    }
-  }
+  const repliesTable = db.table("replies") as CachedRepliesTable;
+
+  const existing = await repliesTable
+    .where({
+      referenceXmtpID: xmtpID,
+      xmtpID: replyXmtpID,
+    })
+    .first();
+
+  return existing
+    ? (existing as CachedReplyWithId).id
+    : repliesTable.add({
+        referenceXmtpID: xmtpID,
+        xmtpID: replyXmtpID,
+      });
 };
 
 /**
  * Retrieve all replies to a cached message
  *
  * @param message Cached message
- * @returns An array of XMTP message IDs
+ * @param db Database instance
+ * @returns An array of reply messages
  */
-export const getReplies = (message: CachedMessage) => {
-  const metadata = message?.metadata?.[NAMESPACE] ?? [];
-  return metadata as CachedRepliesMetadata;
+export const getReplies = async (message: CachedMessage, db: Dexie) => {
+  const repliesTable = db.table("replies") as CachedRepliesTable;
+  const replies = await repliesTable
+    .where({ referenceXmtpID: message.xmtpID })
+    .toArray();
+  if (replies.length > 0) {
+    const messagesTable = db.table("messages") as CachedMessagesTable;
+    const replyMessages = await messagesTable
+      .where("xmtpID")
+      .anyOf(replies.map((reply) => reply.xmtpID))
+      .sortBy("sentAt");
+    return replyMessages;
+  }
+  return [];
 };
 
 /**
  * Check if a cached message has any replies
  *
  * @param message Cached message
+ * @param db Database instance
  * @returns `true` if the message has any replies, `false` otherwise
  */
-export const hasReply = (message: CachedMessage) =>
-  getReplies(message).length > 0;
+export const hasReply = async (message: CachedMessage, db: Dexie) => {
+  const repliesTable = db.table("replies") as CachedRepliesTable;
+  const replies = await repliesTable
+    .where({ referenceXmtpID: message.xmtpID })
+    .toArray();
+  return replies.length > 0;
+};
 
 /**
  * Get the original message from a reply message
@@ -123,7 +156,7 @@ export const processReply: ContentTypeMessageProcessor = async ({
   ) {
     const reply = message.content as Reply;
 
-    // update replies metadata on the referenced message
+    // save the reply to cache
     await addReply(reply.reference, message.xmtpID, db);
 
     // save the message to cache
@@ -136,6 +169,14 @@ export const replyContentTypeConfig: ContentTypeConfiguration = {
   namespace: NAMESPACE,
   processors: {
     [ContentTypeReply.toString()]: [processReply],
+  },
+  schema: {
+    replies: `
+      ++id,
+      [referenceXmtpID+xmtpID],
+      referenceXmtpID,
+      xmtpID
+    `,
   },
   validators: {
     [ContentTypeReply.toString()]: isValidReplyContent,

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reply.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reply.ts
@@ -147,7 +147,6 @@ const isValidReplyContent = (content: unknown) => {
 export const processReply: ContentTypeMessageProcessor = async ({
   message,
   db,
-  persist,
 }) => {
   const contentType = ContentTypeId.fromString(message.contentType);
   if (
@@ -158,14 +157,12 @@ export const processReply: ContentTypeMessageProcessor = async ({
 
     // save the reply to cache
     await addReply(reply.reference, message.xmtpID, db);
-
-    // save the message to cache
-    await persist();
   }
 };
 
 export const replyContentTypeConfig: ContentTypeConfiguration = {
   codecs: [new ReplyCodec()],
+  contentTypes: [ContentTypeReply.toString()],
   namespace: NAMESPACE,
   processors: {
     [ContentTypeReply.toString()]: [processReply],

--- a/packages/react-sdk/src/helpers/caching/contentTypes/reply.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/reply.ts
@@ -5,6 +5,7 @@ import type { Dexie, Table } from "dexie";
 import { z } from "zod";
 import type {
   CachedMessage,
+  CachedMessageWithId,
   CachedMessagesTable,
 } from "@/helpers/caching/messages";
 import type {
@@ -74,7 +75,7 @@ export const getReplies = async (message: CachedMessage, db: Dexie) => {
       .where("xmtpID")
       .anyOf(replies.map((reply) => reply.xmtpID))
       .sortBy("sentAt");
-    return replyMessages;
+    return replyMessages as CachedMessageWithId[];
   }
   return [];
 };

--- a/packages/react-sdk/src/helpers/caching/contentTypes/text.test.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/text.test.ts
@@ -1,115 +1,19 @@
-import { it, expect, describe, vi } from "vitest";
-import { Client, ContentTypeText } from "@xmtp/xmtp-js";
+import { it, expect, describe } from "vitest";
+import { ContentTypeText } from "@xmtp/xmtp-js";
 import {
-  ContentTypeAttachment,
-  type Attachment,
-} from "@xmtp/content-type-remote-attachment";
-import { type CachedMessageWithId } from "@/helpers/caching/messages";
-import { getDbInstance } from "@/helpers/caching/db";
-import type { CachedConversationWithId } from "@/helpers/caching/conversations";
-import {
-  processText,
+  isValidTextContent,
   textContentTypeConfig,
 } from "@/helpers/caching/contentTypes/text";
-import { createRandomWallet } from "@/helpers/testing";
 
-const testWallet = createRandomWallet();
-const db = getDbInstance();
-
-describe("ContentTypeText caching", () => {
-  it("should have the correct content types config", () => {
+describe("ContentTypeText", () => {
+  it("should have the correct config", () => {
     expect(textContentTypeConfig.namespace).toEqual("text");
     expect(textContentTypeConfig.codecs).toEqual([]);
-    expect(
-      textContentTypeConfig.processors?.[ContentTypeText.toString()],
-    ).toEqual([processText]);
-  });
-
-  describe("processText", () => {
-    it("should save a message to the cache", async () => {
-      const testClient = await Client.create(testWallet, { env: "local" });
-      const testConversation = {
-        id: 1,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        isReady: false,
-        topic: "testTopic",
-        peerAddress: "testPeerAddress",
-        walletAddress: testWallet.account.address,
-      } satisfies CachedConversationWithId;
-      const testMessage = {
-        id: 1,
-        walletAddress: testWallet.account.address,
-        conversationTopic: "testTopic",
-        content: "test",
-        contentType: ContentTypeText.toString(),
-        isSending: false,
-        hasLoadError: false,
-        hasSendError: false,
-        sentAt: new Date(),
-        status: "unprocessed",
-        senderAddress: "testWalletAddress",
-        uuid: "testUuid",
-        xmtpID: "testXmtpId",
-      } satisfies CachedMessageWithId;
-
-      const persist = vi.fn();
-      const updateConversationMetadata = vi.fn();
-      await processText({
-        client: testClient,
-        conversation: testConversation,
-        db,
-        message: testMessage,
-        persist,
-        updateConversationMetadata,
-        processors: textContentTypeConfig.processors,
-      });
-      expect(persist).toHaveBeenCalledWith();
-    });
-
-    it("should not process a message with the wrong content type", async () => {
-      const testClient = await Client.create(testWallet, { env: "local" });
-      const testConversation = {
-        id: 1,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        isReady: false,
-        topic: "testTopic",
-        peerAddress: "testPeerAddress",
-        walletAddress: testWallet.account.address,
-      } satisfies CachedConversationWithId;
-      const testMessage = {
-        id: 1,
-        walletAddress: testWallet.account.address,
-        conversationTopic: "testTopic",
-        content: {
-          filename: "testFilename",
-          mimeType: "testMimeType",
-          data: new Uint8Array(),
-        },
-        contentType: ContentTypeAttachment.toString(),
-        isSending: false,
-        hasLoadError: false,
-        hasSendError: false,
-        sentAt: new Date(),
-        status: "unprocessed",
-        senderAddress: "testWalletAddress",
-        uuid: "testUuid",
-        xmtpID: "testXmtpId",
-      } satisfies CachedMessageWithId<Attachment>;
-
-      const persist = vi.fn();
-      const updateConversationMetadata = vi.fn();
-      await processText({
-        client: testClient,
-        conversation: testConversation,
-        db,
-        message: testMessage,
-        persist,
-        updateConversationMetadata,
-        processors: textContentTypeConfig.processors,
-      });
-      expect(persist).not.toHaveBeenCalled();
+    expect(textContentTypeConfig.contentTypes).toEqual([
+      ContentTypeText.toString(),
+    ]);
+    expect(textContentTypeConfig.validators).toEqual({
+      [ContentTypeText.toString()]: isValidTextContent,
     });
   });
 });

--- a/packages/react-sdk/src/helpers/caching/contentTypes/text.ts
+++ b/packages/react-sdk/src/helpers/caching/contentTypes/text.ts
@@ -1,8 +1,5 @@
-import { ContentTypeId, ContentTypeText } from "@xmtp/xmtp-js";
-import type {
-  ContentTypeConfiguration,
-  ContentTypeMessageProcessor,
-} from "../db";
+import { ContentTypeText } from "@xmtp/xmtp-js";
+import type { ContentTypeConfiguration } from "../db";
 
 const NAMESPACE = "text";
 
@@ -12,34 +9,14 @@ const NAMESPACE = "text";
  * @param content Message content
  * @returns `true` if the content is valid, `false` otherwise
  */
-const isValidTextContent = (content: unknown) => typeof content === "string";
-
-/**
- * Process a text message
- *
- * Saves the message to the cache.
- */
-export const processText: ContentTypeMessageProcessor = async ({
-  message,
-  persist,
-}) => {
-  const contentType = ContentTypeId.fromString(message.contentType);
-  if (
-    ContentTypeText.sameAs(contentType) &&
-    isValidTextContent(message.content)
-  ) {
-    // no special processing, just persist the message to cache
-    await persist();
-  }
-};
+export const isValidTextContent = (content: unknown) =>
+  typeof content === "string";
 
 export const textContentTypeConfig: ContentTypeConfiguration = {
-  namespace: NAMESPACE,
   // the text codec is registered automatically in the JS SDK
   codecs: [],
-  processors: {
-    [ContentTypeText.toString()]: [processText],
-  },
+  contentTypes: [ContentTypeText.toString()],
+  namespace: NAMESPACE,
   validators: {
     [ContentTypeText.toString()]: isValidTextContent,
   },

--- a/packages/react-sdk/src/helpers/caching/db.ts
+++ b/packages/react-sdk/src/helpers/caching/db.ts
@@ -1,9 +1,6 @@
 import Dexie from "dexie";
 import type { Client, ContentCodec } from "@xmtp/xmtp-js";
-import type {
-  CachedMessage,
-  CachedMessageWithId,
-} from "@/helpers/caching/messages";
+import type { CachedMessage } from "@/helpers/caching/messages";
 import type { CachedConversation } from "./conversations";
 import { textContentTypeConfig } from "./contentTypes/text";
 
@@ -30,21 +27,16 @@ export type InternalPersistMessageOptions = {
   metadata?: ContentTypeMetadataValues;
 };
 
-export type InternalPersistMessage = (
-  options?: InternalPersistMessageOptions,
-) => Promise<CachedMessageWithId<any>>;
-
 export type ContentTypeMessageProcessor<C = any> = (options: {
   client: Client;
   conversation: CachedConversation;
   db: Dexie;
-  message: CachedMessageWithId<C>;
+  message: CachedMessage<C>;
   processors?: ContentTypeMessageProcessors;
-  persist: InternalPersistMessage;
   updateConversationMetadata: (
     data: ContentTypeMetadataValues,
   ) => Promise<void>;
-}) => Promise<void>;
+}) => void | Promise<void>;
 
 export type ContentTypeMessageValidators = Record<
   string,
@@ -53,6 +45,7 @@ export type ContentTypeMessageValidators = Record<
 
 export type ContentTypeConfiguration = {
   codecs: ContentCodec<any>[];
+  contentTypes: string[];
   namespace: string;
   processors?: ContentTypeMessageProcessors;
   schema?: Record<string, string>;

--- a/packages/react-sdk/src/helpers/combineMessageProcessors.test.ts
+++ b/packages/react-sdk/src/helpers/combineMessageProcessors.test.ts
@@ -1,18 +1,9 @@
 import { it, expect, describe } from "vitest";
-import {
-  ContentTypeAttachment,
-  ContentTypeRemoteAttachment,
-} from "@xmtp/content-type-remote-attachment";
 import { ContentTypeReaction } from "@xmtp/content-type-reaction";
 import { ContentTypeReadReceipt } from "@xmtp/content-type-read-receipt";
 import { ContentTypeReply } from "@xmtp/content-type-reply";
-import { ContentTypeText } from "@xmtp/xmtp-js";
 import { combineMessageProcessors } from "@/helpers/combineMessageProcessors";
-import {
-  attachmentContentTypeConfig,
-  processAttachment,
-  processRemoteAttachment,
-} from "@/helpers/caching/contentTypes/attachment";
+import { attachmentContentTypeConfig } from "@/helpers/caching/contentTypes/attachment";
 import {
   processReaction,
   reactionContentTypeConfig,
@@ -25,7 +16,6 @@ import {
   processReply,
   replyContentTypeConfig,
 } from "@/helpers/caching/contentTypes/reply";
-import { processText } from "@/helpers/caching/contentTypes/text";
 
 const testCacheConfig = [
   attachmentContentTypeConfig,
@@ -37,18 +27,13 @@ const testCacheConfig = [
 describe("combineMessageProcessors", () => {
   it("should combine message processors from a content types config", () => {
     expect(combineMessageProcessors(testCacheConfig)).toEqual({
-      [ContentTypeAttachment.toString()]: [processAttachment],
-      [ContentTypeRemoteAttachment.toString()]: [processRemoteAttachment],
       [ContentTypeReaction.toString()]: [processReaction],
       [ContentTypeReadReceipt.toString()]: [processReadReceipt],
       [ContentTypeReply.toString()]: [processReply],
-      [ContentTypeText.toString()]: [processText],
     });
   });
 
-  it("should only have text message processors without a content types config", () => {
-    expect(combineMessageProcessors()).toEqual({
-      [ContentTypeText.toString()]: [processText],
-    });
+  it("should have no message processors without a content types config", () => {
+    expect(combineMessageProcessors()).toEqual({});
   });
 });

--- a/packages/react-sdk/src/helpers/combineNamespaces.test.ts
+++ b/packages/react-sdk/src/helpers/combineNamespaces.test.ts
@@ -44,9 +44,7 @@ describe("combineNamespaces", () => {
         {
           namespace: "text",
           codecs: [],
-          processors: {
-            foo: [() => Promise.resolve()],
-          },
+          contentTypes: [ContentTypeText.toString()],
         },
       ]),
     ).toThrow(`Duplicate content types config namespace detected: "text"`);

--- a/packages/react-sdk/src/helpers/combineNamespaces.ts
+++ b/packages/react-sdk/src/helpers/combineNamespaces.ts
@@ -29,8 +29,8 @@ export const combineNamespaces = (
       }
       namespaces.push(config.namespace);
       // assign namespaces to content types
-      const names = Object.entries(config.processors ?? []).reduce(
-        (namespacesResult, [contentType]) => ({
+      const names = (config.contentTypes ?? []).reduce(
+        (namespacesResult, contentType) => ({
           ...namespacesResult,
           [contentType]: config.namespace,
         }),

--- a/packages/react-sdk/src/helpers/combineValidators.test.ts
+++ b/packages/react-sdk/src/helpers/combineValidators.test.ts
@@ -35,6 +35,7 @@ describe("combineValidators", () => {
         {
           namespace: "foo",
           codecs: [],
+          contentTypes: [ContentTypeText.toString()],
           processors: {},
           validators: {
             [ContentTypeText.toString()]: () => false,

--- a/packages/react-sdk/src/hooks/useReplies.ts
+++ b/packages/react-sdk/src/hooks/useReplies.ts
@@ -1,0 +1,22 @@
+import { useLiveQuery } from "dexie-react-hooks";
+import { useDb } from "./useDb";
+import type { CachedMessage } from "@/helpers/caching/messages";
+import { getReplies } from "@/helpers/caching/contentTypes/reply";
+
+/**
+ * This hook returns cached replies to a message from the local cache
+ */
+export const useReplies = (message?: CachedMessage) => {
+  const { db } = useDb();
+
+  return (
+    useLiveQuery(async () => {
+      if (!message) return [];
+      try {
+        return await getReplies(message, db);
+      } catch {
+        return [];
+      }
+    }, [message]) ?? []
+  );
+};

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -31,6 +31,7 @@ export { useReactions } from "./hooks/useReactions";
 
 // replies
 export { useReply } from "./hooks/useReply";
+export { useReplies } from "./hooks/useReplies";
 
 // caching
 export { getDbInstance, clearCache } from "./helpers/caching/db";
@@ -107,7 +108,6 @@ export {
 } from "./helpers/caching/contentTypes/readReceipt";
 
 // replies
-export type { CachedRepliesMetadata } from "./helpers/caching/contentTypes/reply";
 export {
   getReplies,
   getOriginalMessageFromReply,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8078,6 +8078,8 @@ __metadata:
     "@types/react": ^18.2.20
     "@types/react-dom": ^18.2.8
     "@vitejs/plugin-react": ^4.1.0
+    "@xmtp/content-type-reaction": ^1.1.3
+    "@xmtp/content-type-read-receipt": ^1.1.5
     "@xmtp/content-type-remote-attachment": ^1.1.4
     "@xmtp/react-components": "workspace:*"
     "@xmtp/react-sdk": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8011,18 +8011,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/proto@npm:^3.28.0-beta.1":
-  version: 3.28.0-beta.1
-  resolution: "@xmtp/proto@npm:3.28.0-beta.1"
-  dependencies:
-    long: ^5.2.0
-    protobufjs: ^7.0.0
-    rxjs: ^7.8.0
-    undici: ^5.8.1
-  checksum: d222356318e72359bf54aea0fb967c3beeac94c82649c2e9c8cdb0a5a01ecf5c1264af1f1a4d2eeffb0d8b05561f0e3ee9b1ee44fa5742edfb0e1b288af8b96d
-  languageName: node
-  linkType: hard
-
 "@xmtp/proto@npm:^3.29.0":
   version: 3.29.0
   resolution: "@xmtp/proto@npm:3.29.0"
@@ -8124,7 +8112,7 @@ __metadata:
     "@xmtp/content-type-remote-attachment": ^1.1.4
     "@xmtp/content-type-reply": ^1.1.5
     "@xmtp/tsconfig": "workspace:*"
-    "@xmtp/xmtp-js": ^11.1.2
+    "@xmtp/xmtp-js": ^11.2.0
     async-mutex: ^0.4.0
     date-fns: ^2.30.0
     dexie: ^3.2.4
@@ -8146,7 +8134,7 @@ __metadata:
     vitest: ^0.34.2
     zod: ^3.22.2
   peerDependencies:
-    "@xmtp/xmtp-js": ^11.1.1
+    "@xmtp/xmtp-js": ^11.2.0
     react: ">=16.14"
   languageName: unknown
   linkType: soft
@@ -8157,17 +8145,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/xmtp-js@npm:^11.1.1":
-  version: 11.1.1
-  resolution: "@xmtp/xmtp-js@npm:11.1.1"
+"@xmtp/xmtp-js@npm:^11.2.0":
+  version: 11.2.0
+  resolution: "@xmtp/xmtp-js@npm:11.2.0"
   dependencies:
     "@noble/secp256k1": ^1.5.2
-    "@xmtp/proto": ^3.28.0-beta.1
+    "@xmtp/proto": ^3.29.0
     async-mutex: ^0.4.0
     elliptic: ^6.5.4
     ethers: ^5.5.3
     long: ^5.2.0
-  checksum: 208c5606c1d207d8141867067708b872a495cad27ca3327f0797479ac76f3e6c5d2c163bf6c2416cf7b06a33bcb3e00ee51077d902236339e4387bc2113bfa90
+  checksum: 11fbe2d051fd7c121cde43c49de1acedc3b275106b1e09a444fbb0a4bce8b8111a4bc20c4fcbe8d0a474d876b3d3117eebea6453efb18065391afa7fa7334105
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
in this PR:

* upgraded JS SDK to `11.2.0`
* refactored message sending to prepare messages prior to sending
* refactored message processing to always cache messages
* added `contentTypes` to content type config
* removed unnecessary processors from some content type configs
* added guard to prevent sending messages that haven't been fully processed
* added `replies` table to local cache
* updated reply helpers to work with new `replies` table
* added `useReplies` hook that return replies to a specified message
* updated unit tests
* added message filters for replies and read receipts in the example app