### PR TITLE
Fix `actions/setup-node`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.14.0
           cache: "yarn"
+        env:
+          SKIP_YARN_COREPACK_CHECK: "1"
       - name: Install Yarn v3
         run: |
           corepack enable
@@ -24,10 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.14.0
           cache: "yarn"
+        env:
+          SKIP_YARN_COREPACK_CHECK: "1"
       - name: Install Yarn v3
         run: |
           corepack enable
@@ -41,10 +45,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.14.0
           cache: "yarn"
+        env:
+          SKIP_YARN_COREPACK_CHECK: "1"
       - name: Install Yarn v3
         run: |
           corepack enable
@@ -62,10 +68,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.14.0
           cache: "yarn"
+        env:
+          SKIP_YARN_COREPACK_CHECK: "1"
       - name: Install Yarn v3
         run: |
           corepack enable

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.14.0
           cache: "yarn"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.14.0
           cache: "yarn"


### PR DESCRIPTION
in this PR:

- upgraded `actions/setup-node` to `v4`
- added `SKIP_YARN_COREPACK_CHECK` env var to prevent version errors

there will be no release for these changes.