### PR TITLE
Fix MetaMask snaps integration

### DIFF
--- a/.changeset/modern-toes-share.md
+++ b/.changeset/modern-toes-share.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-sdk": patch
+---
+
+Fix MetaMask snaps integration

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "@changesets/cli": "^2.27.1"
   },
   "resolutions": {
-    "@xmtp/xmtp-js": "^11.3.5"
+    "@xmtp/xmtp-js": "^11.3.7"
   }
 }

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -73,7 +73,7 @@
     "@xmtp/content-type-reaction": "^1.1.5",
     "@xmtp/content-type-remote-attachment": "^1.1.6",
     "@xmtp/content-type-reply": "^1.1.7",
-    "@xmtp/xmtp-js": "^11.3.5",
+    "@xmtp/xmtp-js": "^11.3.7",
     "async-mutex": "^0.4.1",
     "date-fns": "^3.3.1",
     "dexie": "^3.2.4",
@@ -111,7 +111,7 @@
     "vitest": "^1.2.1"
   },
   "peerDependencies": {
-    "@xmtp/xmtp-js": "^11.3.5",
+    "@xmtp/xmtp-js": "^11.3.7",
     "react": ">=16.14"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4362,7 +4362,7 @@ __metadata:
     "@xmtp/content-type-remote-attachment": "npm:^1.1.6"
     "@xmtp/content-type-reply": "npm:^1.1.7"
     "@xmtp/tsconfig": "workspace:*"
-    "@xmtp/xmtp-js": "npm:^11.3.5"
+    "@xmtp/xmtp-js": "npm:^11.3.7"
     async-mutex: "npm:^0.4.1"
     date-fns: "npm:^3.3.1"
     dexie: "npm:^3.2.4"
@@ -4387,7 +4387,7 @@ __metadata:
     vitest: "npm:^1.2.1"
     zod: "npm:^3.22.4"
   peerDependencies:
-    "@xmtp/xmtp-js": ^11.3.5
+    "@xmtp/xmtp-js": ^11.3.7
     react: ">=16.14"
   languageName: unknown
   linkType: soft
@@ -4429,9 +4429,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/xmtp-js@npm:^11.3.5":
-  version: 11.3.5
-  resolution: "@xmtp/xmtp-js@npm:11.3.5"
+"@xmtp/xmtp-js@npm:^11.3.7":
+  version: 11.3.7
+  resolution: "@xmtp/xmtp-js@npm:11.3.7"
   dependencies:
     "@noble/secp256k1": "npm:^1.5.2"
     "@xmtp/proto": "npm:^3.34.0"
@@ -4441,7 +4441,7 @@ __metadata:
     ethers: "npm:^5.5.3"
     js-sha3: "npm:^0.9.3"
     long: "npm:^5.2.0"
-  checksum: d3b51af91cccbb2a8e131049fdec3ed2b02a9002069bc9f865d83c03aa888b5a191d3c15c0fa179f3c56caa7425dfe1b2a1bf3bb4e376c9794b2d8851c607cee
+  checksum: 7edc06ea2517c5879f057d17d065a1bfef8f6abd13c8bdc892bb137a7ecc8e2b07a424f98f98c93e121201e87526453ca9eaa79f937b194a8dd2516bee102fcd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
a bug was introduced in the JS SDK that breaks the MetaMask snaps integration. this PR upgrades to the latest version with a fix.