### PR TITLE
Add support for multiple wallets to consent

### DIFF
--- a/.changeset/forty-otters-drop.md
+++ b/.changeset/forty-otters-drop.md
@@ -1,5 +1,7 @@
 ---
-"@xmtp/react-sdk": patch
+"@xmtp/react-sdk": major
 ---
 
 Add support for multiple wallets to consent
+
+Since this changes the API of several exports, it's a breaking change that requires a major release.

--- a/.changeset/forty-otters-drop.md
+++ b/.changeset/forty-otters-drop.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-sdk": patch
+---
+
+Add support for multiple wallets to consent

--- a/packages/react-sdk/src/helpers/caching/db.ts
+++ b/packages/react-sdk/src/helpers/caching/db.ts
@@ -107,8 +107,10 @@ export const getDbInstance = (options?: GetDBInstanceOptions) => {
         xmtpID
       `,
       consent: `
+        [walletAddress+peerAddress],
         peerAddress,
-        state
+        state,
+        walletAddress
       `,
     });
   }

--- a/packages/react-sdk/src/hooks/useConsent.test.tsx
+++ b/packages/react-sdk/src/hooks/useConsent.test.tsx
@@ -50,12 +50,14 @@ describe("useConsent", () => {
       await result.current.allow([testWallet2.account.address]);
       expect(allowSpy).toHaveBeenCalledWith([testWallet2.account.address]);
       const entry = await getCachedConsentState(
+        testWallet1.account.address,
         testWallet2.account.address,
         db,
       );
       expect(entry).toEqual({
         peerAddress: testWallet2.account.address,
         state: "allowed",
+        walletAddress: testWallet1.account.address,
       });
     });
   });
@@ -74,12 +76,14 @@ describe("useConsent", () => {
       await result.current.deny([testWallet2.account.address]);
       expect(allowSpy).toHaveBeenCalledWith([testWallet2.account.address]);
       const entry = await getCachedConsentState(
+        testWallet1.account.address,
         testWallet2.account.address,
         db,
       );
       expect(entry).toEqual({
         peerAddress: testWallet2.account.address,
         state: "denied",
+        walletAddress: testWallet1.account.address,
       });
     });
   });
@@ -100,7 +104,10 @@ describe("useConsent", () => {
       expect(list2[0].entryType).toEqual("address");
       expect(list2[0].permissionType).toEqual("allowed");
       expect(list2[0].value).toEqual(testWallet2.account.address);
-      const entries = await getCachedConsentEntries(db);
+      const entries = await getCachedConsentEntries(
+        testWallet1.account.address,
+        db,
+      );
       expect(entries.length).toEqual(1);
       expect(entries[0].entryType).toEqual("address");
       expect(entries[0].permissionType).toEqual("allowed");
@@ -124,7 +131,10 @@ describe("useConsent", () => {
       expect(list2[0].entryType).toEqual("address");
       expect(list2[0].permissionType).toEqual("allowed");
       expect(list2[0].value).toEqual(testWallet4.account.address);
-      const entries = await getCachedConsentEntries(db);
+      const entries = await getCachedConsentEntries(
+        testWallet3.account.address,
+        db,
+      );
       expect(entries.length).toEqual(1);
       expect(entries[0].entryType).toEqual("address");
       expect(entries[0].permissionType).toEqual("allowed");


### PR DESCRIPTION
when consent support was initially added, it didn't support multiple wallets. this update adds support for multiple wallets when working with consent.