### PR TITLE
Fix existing conversation lookup

### DIFF
--- a/.changeset/mighty-eggs-vanish.md
+++ b/.changeset/mighty-eggs-vanish.md
@@ -1,0 +1,6 @@
+---
+"@xmtp/react-sdk": patch
+---
+
+Fix existing conversation lookup by adding `walletAddress` to DB query
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,10 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version-file: ".node-version"
           cache: "yarn"
         env:
           SKIP_YARN_COREPACK_CHECK: "1"
@@ -23,10 +23,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version-file: ".node-version"
           cache: "yarn"
         env:
           SKIP_YARN_COREPACK_CHECK: "1"
@@ -40,10 +40,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version-file: ".node-version"
           cache: "yarn"
         env:
           SKIP_YARN_COREPACK_CHECK: "1"
@@ -61,10 +61,10 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version-file: ".node-version"
           cache: "yarn"
         env:
           SKIP_YARN_COREPACK_CHECK: "1"
@@ -78,10 +78,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version-file: ".node-version"
           cache: "yarn"
         env:
           SKIP_YARN_COREPACK_CHECK: "1"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,10 +12,10 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version-file: ".node-version"
           cache: "yarn"
         env:
           SKIP_YARN_COREPACK_CHECK: "1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version-file: ".node-version"
           cache: "yarn"
         env:
           SKIP_YARN_COREPACK_CHECK: "1"

--- a/packages/react-sdk/src/helpers/caching/conversations.ts
+++ b/packages/react-sdk/src/helpers/caching/conversations.ts
@@ -203,8 +203,10 @@ export const saveConversation = async (
     const conversations = db.table("conversations") as CachedConversationsTable;
 
     const existing = await conversations
-      .where("topic")
-      .equals(conversation.topic)
+      .where({
+        walletAddress: conversation.walletAddress,
+        topic: conversation.topic,
+      })
       .first();
 
     if (existing) {


### PR DESCRIPTION
if a user has multiple wallets and they are messaging between these wallets, new conversations would fail to save to the local DB and return from the `useConversations` hook. the reason for this is the conversation topic already existed in the DB and the current wallet address was not part of the DB query to determine if the conversation had already been saved.

resolves #163 

in this PR:

- fixed existing conversation lookup by adding `walletAddress` to DB query
- updated GitHub actions

