### PR TITLE
Ensure consent DB is in sync with the network

### DIFF
--- a/.changeset/nice-parents-cheat.md
+++ b/.changeset/nice-parents-cheat.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/react-sdk": patch
+---
+
+Ensure consent DB is in sync with the network

--- a/apps/react/src/components/ConversationCard.tsx
+++ b/apps/react/src/components/ConversationCard.tsx
@@ -1,5 +1,6 @@
-import type { CachedConversation } from "@xmtp/react-sdk";
+import type { CachedConversation, ConsentState } from "@xmtp/react-sdk";
 import { useLastMessage, useConsent } from "@xmtp/react-sdk";
+import { useEffect, useState } from "react";
 import { ConversationPreview } from "../controllers/ConversationPreview";
 
 type ConversationCardProps = {
@@ -13,8 +14,17 @@ export const ConversationCard: React.FC<ConversationCardProps> = ({
   onConversationClick,
   isSelected,
 }) => {
+  const [consentState, setConsentState] = useState<ConsentState>("unknown");
   const lastMessage = useLastMessage(conversation.topic);
-  const { consentState } = useConsent();
+  const { consentState: _consentState } = useConsent();
+
+  useEffect(() => {
+    const getState = async () => {
+      setConsentState(await _consentState(conversation.peerAddress));
+    };
+    void getState();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <ConversationPreview
@@ -23,7 +33,7 @@ export const ConversationCard: React.FC<ConversationCardProps> = ({
       isSelected={isSelected}
       onClick={onConversationClick}
       lastMessage={lastMessage}
-      consentState={consentState(conversation.peerAddress)}
+      consentState={consentState}
     />
   );
 };

--- a/apps/react/src/components/ConversationCard.tsx
+++ b/apps/react/src/components/ConversationCard.tsx
@@ -1,6 +1,5 @@
-import type { CachedConversation, ConsentState } from "@xmtp/react-sdk";
+import type { CachedConversation } from "@xmtp/react-sdk";
 import { useLastMessage, useConsent } from "@xmtp/react-sdk";
-import { useEffect, useState } from "react";
 import { ConversationPreview } from "../controllers/ConversationPreview";
 
 type ConversationCardProps = {
@@ -14,17 +13,8 @@ export const ConversationCard: React.FC<ConversationCardProps> = ({
   onConversationClick,
   isSelected,
 }) => {
-  const [consentState, setConsentState] = useState<ConsentState>("unknown");
   const lastMessage = useLastMessage(conversation.topic);
-  const { consentState: _consentState } = useConsent();
-
-  useEffect(() => {
-    const getState = async () => {
-      setConsentState(await _consentState(conversation.peerAddress));
-    };
-    void getState();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const { entries } = useConsent();
 
   return (
     <ConversationPreview
@@ -33,7 +23,9 @@ export const ConversationCard: React.FC<ConversationCardProps> = ({
       isSelected={isSelected}
       onClick={onConversationClick}
       lastMessage={lastMessage}
-      consentState={consentState}
+      consentState={
+        entries[conversation.peerAddress]?.permissionType ?? "unknown"
+      }
     />
   );
 };

--- a/packages/react-sdk/src/helpers/caching/consent.test.ts
+++ b/packages/react-sdk/src/helpers/caching/consent.test.ts
@@ -98,17 +98,25 @@ describe("Consent helpers", () => {
         testWallet1.account.address,
         db,
       );
-      expect(entries[0].entryType).toBe("address");
-      expect(entries[0].value).toBe(testWallet2.account.address);
-      expect(entries[0].permissionType).toBe("allowed");
+      expect(entries[testWallet2.account.address]?.entryType).toBe("address");
+      expect(entries[testWallet2.account.address]?.value).toBe(
+        testWallet2.account.address,
+      );
+      expect(entries[testWallet2.account.address]?.permissionType).toBe(
+        "allowed",
+      );
 
       const entries2 = await getCachedConsentEntries(
         testWallet2.account.address,
         db,
       );
-      expect(entries2[0].entryType).toBe("address");
-      expect(entries2[0].value).toBe(testWallet1.account.address);
-      expect(entries2[0].permissionType).toBe("denied");
+      expect(entries2[testWallet1.account.address]?.entryType).toBe("address");
+      expect(entries2[testWallet1.account.address]?.value).toBe(
+        testWallet1.account.address,
+      );
+      expect(entries2[testWallet1.account.address]?.permissionType).toBe(
+        "denied",
+      );
     });
   });
 

--- a/packages/react-sdk/src/helpers/caching/consent.test.ts
+++ b/packages/react-sdk/src/helpers/caching/consent.test.ts
@@ -5,6 +5,7 @@ import { createRandomWallet } from "@/helpers/testing";
 import {
   bulkPutConsentState,
   getCachedConsentEntries,
+  getCachedConsentEntry,
   getCachedConsentState,
   loadConsentListFromCache,
   putConsentState,
@@ -22,7 +23,7 @@ beforeEach(async () => {
 describe("Consent helpers", () => {
   describe("putConsentState", () => {
     it("should add a new entry and update it", async () => {
-      const undefinedEntry = await getCachedConsentState(
+      const undefinedEntry = await getCachedConsentEntry(
         testWallet1.account.address,
         testWallet2.account.address,
         db,
@@ -34,7 +35,7 @@ describe("Consent helpers", () => {
         "allowed",
         db,
       );
-      const entry = await getCachedConsentState(
+      const entry = await getCachedConsentEntry(
         testWallet1.account.address,
         testWallet2.account.address,
         db,
@@ -44,13 +45,19 @@ describe("Consent helpers", () => {
         state: "allowed",
         walletAddress: testWallet1.account.address,
       });
+      const state = await getCachedConsentState(
+        testWallet1.account.address,
+        testWallet2.account.address,
+        db,
+      );
+      expect(state).toBe("allowed");
       await putConsentState(
         testWallet1.account.address,
         testWallet2.account.address,
         "denied",
         db,
       );
-      const updatedEntry = await getCachedConsentState(
+      const updatedEntry = await getCachedConsentEntry(
         testWallet1.account.address,
         testWallet2.account.address,
         db,
@@ -60,6 +67,12 @@ describe("Consent helpers", () => {
         state: "denied",
         walletAddress: testWallet1.account.address,
       });
+      const updatedState = await getCachedConsentState(
+        testWallet1.account.address,
+        testWallet2.account.address,
+        db,
+      );
+      expect(updatedState).toBe("denied");
     });
   });
 

--- a/packages/react-sdk/src/helpers/caching/consent.test.ts
+++ b/packages/react-sdk/src/helpers/caching/consent.test.ts
@@ -98,25 +98,17 @@ describe("Consent helpers", () => {
         testWallet1.account.address,
         db,
       );
-      expect(entries[testWallet2.account.address]?.entryType).toBe("address");
-      expect(entries[testWallet2.account.address]?.value).toBe(
-        testWallet2.account.address,
-      );
-      expect(entries[testWallet2.account.address]?.permissionType).toBe(
-        "allowed",
-      );
+      expect(entries[0].entryType).toBe("address");
+      expect(entries[0].value).toBe(testWallet2.account.address);
+      expect(entries[0].permissionType).toBe("allowed");
 
       const entries2 = await getCachedConsentEntries(
         testWallet2.account.address,
         db,
       );
-      expect(entries2[testWallet1.account.address]?.entryType).toBe("address");
-      expect(entries2[testWallet1.account.address]?.value).toBe(
-        testWallet1.account.address,
-      );
-      expect(entries2[testWallet1.account.address]?.permissionType).toBe(
-        "denied",
-      );
+      expect(entries2[0].entryType).toBe("address");
+      expect(entries2[0].value).toBe(testWallet1.account.address);
+      expect(entries2[0].permissionType).toBe("denied");
     });
   });
 

--- a/packages/react-sdk/src/helpers/caching/consent.ts
+++ b/packages/react-sdk/src/helpers/caching/consent.ts
@@ -13,11 +13,11 @@ export type CachedConsentEntry = {
 export type CachedConsentTable = Table<CachedConsentEntry, string>;
 
 /**
- * Retrieve a cached consent state by wallet and peer address
+ * Retrieve a cached consent entry by wallet and peer address
  *
- * @returns The cached consent state if found, otherwise `undefined`
+ * @returns The cached consent entry if found, otherwise `undefined`
  */
-export const getCachedConsentState = async (
+export const getCachedConsentEntry = async (
   walletAddress: string,
   peerAddress: string,
   db: Dexie,
@@ -46,6 +46,20 @@ export const getCachedConsentEntries = async (
   return entries.map((entry) =>
     ConsentListEntry.fromAddress(entry.peerAddress, entry.state),
   );
+};
+
+/**
+ * Retrieve a cached consent state by wallet and peer address
+ *
+ * @returns The cached consent state if found, otherwise `undefined`
+ */
+export const getCachedConsentState = async (
+  walletAddress: string,
+  peerAddress: string,
+  db: Dexie,
+) => {
+  const entry = await getCachedConsentEntry(walletAddress, peerAddress, db);
+  return entry?.state ?? "unknown";
 };
 
 /**

--- a/packages/react-sdk/src/hooks/useCachedConsentEntries.ts
+++ b/packages/react-sdk/src/hooks/useCachedConsentEntries.ts
@@ -1,7 +1,7 @@
 import { useLiveQuery } from "dexie-react-hooks";
 import { useDb } from "./useDb";
 import { useClient } from "@/hooks/useClient";
-import { getCachedConsentEntries } from "@/helpers/caching/consent";
+import { getCachedConsentEntriesMap } from "@/helpers/caching/consent";
 
 /**
  * This hook returns cached consent entries from the local cache based on the
@@ -18,7 +18,7 @@ export const useCachedConsentEntries = () => {
       if (!client) {
         return {};
       }
-      return getCachedConsentEntries(client.address, db);
+      return getCachedConsentEntriesMap(client.address, db);
     }, [client?.address]) ?? {}
   );
 };

--- a/packages/react-sdk/src/hooks/useCachedConsentEntries.ts
+++ b/packages/react-sdk/src/hooks/useCachedConsentEntries.ts
@@ -1,0 +1,24 @@
+import { useLiveQuery } from "dexie-react-hooks";
+import { useDb } from "./useDb";
+import { useClient } from "@/hooks/useClient";
+import { getCachedConsentEntries } from "@/helpers/caching/consent";
+
+/**
+ * This hook returns cached consent entries from the local cache based on the
+ * current client's address
+ *
+ * It's intended to be used internally and is not exported from the SDK
+ */
+export const useCachedConsentEntries = () => {
+  const { db } = useDb();
+  const { client } = useClient();
+  return (
+    useLiveQuery(async () => {
+      // client required for address
+      if (!client) {
+        return {};
+      }
+      return getCachedConsentEntries(client.address, db);
+    }, [client?.address]) ?? {}
+  );
+};

--- a/packages/react-sdk/src/hooks/useConsent.test.tsx
+++ b/packages/react-sdk/src/hooks/useConsent.test.tsx
@@ -101,15 +101,9 @@ describe("useConsent", () => {
         db,
       );
       expect(Object.keys(entries).length).toEqual(1);
-      expect(entries[testWallet2.account.address]?.entryType).toEqual(
-        "address",
-      );
-      expect(entries[testWallet2.account.address]?.permissionType).toEqual(
-        "allowed",
-      );
-      expect(entries[testWallet2.account.address]?.value).toEqual(
-        testWallet2.account.address,
-      );
+      expect(entries[0].entryType).toEqual("address");
+      expect(entries[0].permissionType).toEqual("allowed");
+      expect(entries[0].value).toEqual(testWallet2.account.address);
     });
   });
 
@@ -134,15 +128,9 @@ describe("useConsent", () => {
         db,
       );
       expect(Object.keys(entries).length).toEqual(1);
-      expect(entries[testWallet4.account.address]?.entryType).toEqual(
-        "address",
-      );
-      expect(entries[testWallet4.account.address]?.permissionType).toEqual(
-        "allowed",
-      );
-      expect(entries[testWallet4.account.address]?.value).toEqual(
-        testWallet4.account.address,
-      );
+      expect(entries[0].entryType).toEqual("address");
+      expect(entries[0].permissionType).toEqual("allowed");
+      expect(entries[0].value).toEqual(testWallet4.account.address);
     });
   });
 });

--- a/packages/react-sdk/src/hooks/useConsent.test.tsx
+++ b/packages/react-sdk/src/hooks/useConsent.test.tsx
@@ -100,10 +100,16 @@ describe("useConsent", () => {
         testWallet1.account.address,
         db,
       );
-      expect(entries.length).toEqual(1);
-      expect(entries[0].entryType).toEqual("address");
-      expect(entries[0].permissionType).toEqual("allowed");
-      expect(entries[0].value).toEqual(testWallet2.account.address);
+      expect(Object.keys(entries).length).toEqual(1);
+      expect(entries[testWallet2.account.address]?.entryType).toEqual(
+        "address",
+      );
+      expect(entries[testWallet2.account.address]?.permissionType).toEqual(
+        "allowed",
+      );
+      expect(entries[testWallet2.account.address]?.value).toEqual(
+        testWallet2.account.address,
+      );
     });
   });
 
@@ -127,10 +133,16 @@ describe("useConsent", () => {
         testWallet3.account.address,
         db,
       );
-      expect(entries.length).toEqual(1);
-      expect(entries[0].entryType).toEqual("address");
-      expect(entries[0].permissionType).toEqual("allowed");
-      expect(entries[0].value).toEqual(testWallet4.account.address);
+      expect(Object.keys(entries).length).toEqual(1);
+      expect(entries[testWallet4.account.address]?.entryType).toEqual(
+        "address",
+      );
+      expect(entries[testWallet4.account.address]?.permissionType).toEqual(
+        "allowed",
+      );
+      expect(entries[testWallet4.account.address]?.value).toEqual(
+        testWallet4.account.address,
+      );
     });
   });
 });

--- a/packages/react-sdk/src/hooks/useConsent.test.tsx
+++ b/packages/react-sdk/src/hooks/useConsent.test.tsx
@@ -49,16 +49,12 @@ describe("useConsent", () => {
     await act(async () => {
       await result.current.allow([testWallet2.account.address]);
       expect(allowSpy).toHaveBeenCalledWith([testWallet2.account.address]);
-      const entry = await getCachedConsentState(
+      const state = await getCachedConsentState(
         testWallet1.account.address,
         testWallet2.account.address,
         db,
       );
-      expect(entry).toEqual({
-        peerAddress: testWallet2.account.address,
-        state: "allowed",
-        walletAddress: testWallet1.account.address,
-      });
+      expect(state).toBe("allowed");
     });
   });
 
@@ -75,16 +71,12 @@ describe("useConsent", () => {
     await act(async () => {
       await result.current.deny([testWallet2.account.address]);
       expect(allowSpy).toHaveBeenCalledWith([testWallet2.account.address]);
-      const entry = await getCachedConsentState(
+      const state = await getCachedConsentState(
         testWallet1.account.address,
         testWallet2.account.address,
         db,
       );
-      expect(entry).toEqual({
-        peerAddress: testWallet2.account.address,
-        state: "denied",
-        walletAddress: testWallet1.account.address,
-      });
+      expect(state).toBe("denied");
     });
   });
 

--- a/packages/react-sdk/src/hooks/useSendMessage.ts
+++ b/packages/react-sdk/src/hooks/useSendMessage.ts
@@ -3,7 +3,7 @@ import { useCallback, useState } from "react";
 import type { OnError } from "../sharedTypes";
 import { type CachedConversation } from "@/helpers/caching/conversations";
 import { useMessage } from "@/hooks/useMessage";
-import { useConsent } from "@/index";
+import { useConsent } from "@/hooks/useConsent";
 
 export type UseSendMessageOptions = OnError & {
   /**

--- a/packages/react-sdk/src/hooks/useStreamConsentList.ts
+++ b/packages/react-sdk/src/hooks/useStreamConsentList.ts
@@ -2,7 +2,7 @@ import type { PrivatePreferencesAction, Stream } from "@xmtp/xmtp-js";
 import { useEffect, useRef, useState } from "react";
 import { useClient } from "./useClient";
 import type { OnError } from "../sharedTypes";
-import { useConsent } from "@/index";
+import { useConsent } from "@/hooks/useConsent";
 
 export type ConsentListStream = Promise<
   Stream<PrivatePreferencesAction, string>

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -71,6 +71,7 @@ export {
   bulkPutConsentState,
   getCachedConsentEntry,
   getCachedConsentEntries,
+  getCachedConsentEntriesMap,
   getCachedConsentState,
   loadConsentListFromCache,
   putConsentState,

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -65,9 +65,11 @@ export { useStreamConsentList } from "./hooks/useStreamConsentList";
 export type {
   CachedConsentEntry,
   CachedConsentTable,
+  CachedConsentEntryMap,
 } from "./helpers/caching/consent";
 export {
   bulkPutConsentState,
+  getCachedConsentEntry,
   getCachedConsentEntries,
   getCachedConsentState,
   loadConsentListFromCache,


### PR DESCRIPTION
in this PR:

- refactored `getCachedConsentState` to return a state string
- added `getCachedConsentEntry` helper to return the entire consent entry
- added `getCachedConsentEntriesMap` helper to return an object map of peer addresses and their `ConsentListEntry`
- added `useCachedConsentEntries` hook
- updated `useConsent` hook helpers to always rely on the DB as the source of truth
- added `entries` export to `useConsent` hook
- added `skipPublish` option to `allow` and `deny` helpers to only update the local DB when `true`
- added check to ensure consent state is in sync after sending a message
- added local DB syncing when streaming consent list actions
- added/updated tests