### PR TITLE
Add new frames proxy

### DIFF
--- a/.changeset/long-yaks-attack.md
+++ b/.changeset/long-yaks-attack.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/frames-client": minor
+---
+
+Add new Frames Proxy service and support for redirects and image URLs

--- a/packages/frames-client/README.md
+++ b/packages/frames-client/README.md
@@ -9,7 +9,12 @@ const framesClient = new FramesClient(xmtpClient);
 const frameUrl = "https://www.myframe.xyz";
 
 // Read data from a frame
-const frameMetadata = await readMetadata(frameUrl);
+const frameMetadata = await framesClient.proxy.readMetadata(frameUrl);
+
+// Get a proxied image URL, which you can use directly in an <image> tag
+const imageUrl = framesClient.proxy.mediaUrl(
+  frameMetadata.metaTags["fc:frame:image"],
+);
 
 // Handle a click to button 2 from a conversation with topic "/xmtp/0/123" and participant addresses "abc" and "xyz"
 const payload = await signFrameAction({
@@ -18,5 +23,12 @@ const payload = await signFrameAction({
   conversationTopic: "/xmtp/0/123",
   participantAccountAddresses: ["abc", "xyz"],
 });
-const updatedFrameMetadata = await postToFrame(frameUrl, payload);
+
+// If the button action type was `post`
+const updatedFrameMetadata = await framesClient.proxy.post(frameUrl, payload);
+// If the button action type was `post_redirect`
+const { redirectedTo } = await framesClient.proxy.postRedirect(
+  frameUrl,
+  payload,
+);
 ```

--- a/packages/frames-client/src/constants.ts
+++ b/packages/frames-client/src/constants.ts
@@ -1,3 +1,3 @@
-export const OG_PROXY_URL = "https://og-proxy.fly.dev";
+export const OPEN_FRAMES_PROXY_URL = "https://open-frames-proxy.fly.dev/";
 
 export const PROTOCOL_VERSION = "2024-02-09";

--- a/packages/frames-client/src/index.test.ts
+++ b/packages/frames-client/src/index.test.ts
@@ -70,21 +70,28 @@ describe("signFrameAction", () => {
   });
 
   // Will add E2E tests back once we have Frames deployed with the new schema
-  // it("works e2e", async () => {
-  //   const frameUrl =
-  //     "https://fc-polls-five.vercel.app/polls/01032f47-e976-42ee-9e3d-3aac1324f4b8";
-  //   const metadata = await FramesClient.readMetadata(frameUrl);
-  //   expect(metadata).toBeDefined();
-  //   const signedPayload = await framesClient.signFrameAction(
-  //     frameUrl,
-  //     1,
-  //     "foo",
-  //     "bar",
-  //   );
-  //   console.log(signedPayload);
-  //   const postUrl = metadata.extractedTags["fc:frame:post_url"];
-  //   console.log("posting to", postUrl);
-  //   const response = await FramesClient.postToFrame(postUrl, signedPayload);
-  //   console.log(response);
-  // });
+  it("works e2e", async () => {
+    const frameUrl =
+      "https://fc-polls-five.vercel.app/polls/01032f47-e976-42ee-9e3d-3aac1324f4b8";
+
+    const metadata = await framesClient.proxy.readMetadata(frameUrl);
+    expect(metadata).toBeDefined();
+    const signedPayload = await framesClient.signFrameAction({
+      frameUrl,
+      buttonIndex: 1,
+      conversationTopic: "foo",
+      participantAccountAddresses: ["amal", "bola"],
+    });
+    const postUrl = metadata.metaTags["fc:frame:post_url"];
+    const response = await framesClient.proxy.post(postUrl, signedPayload);
+    expect(response).toBeDefined();
+    expect(response.metaTags["fc:frame"]).toEqual("vNext");
+
+    const imageUrl = response.metaTags["fc:frame:image"];
+    const mediaUrl = framesClient.proxy.mediaUrl(imageUrl);
+
+    const downloadedMedia = await fetch(mediaUrl);
+    expect(downloadedMedia.ok).toBeTruthy();
+    expect(downloadedMedia.headers.get("content-type")).toEqual("image/png");
+  });
 });

--- a/packages/frames-client/src/index.test.ts
+++ b/packages/frames-client/src/index.test.ts
@@ -70,28 +70,33 @@ describe("signFrameAction", () => {
   });
 
   // Will add E2E tests back once we have Frames deployed with the new schema
-  it("works e2e", async () => {
-    const frameUrl =
-      "https://fc-polls-five.vercel.app/polls/01032f47-e976-42ee-9e3d-3aac1324f4b8";
+  it(
+    "works e2e",
+    async () => {
+      const frameUrl =
+        "https://fc-polls-five.vercel.app/polls/01032f47-e976-42ee-9e3d-3aac1324f4b8";
 
-    const metadata = await framesClient.proxy.readMetadata(frameUrl);
-    expect(metadata).toBeDefined();
-    const signedPayload = await framesClient.signFrameAction({
-      frameUrl,
-      buttonIndex: 1,
-      conversationTopic: "foo",
-      participantAccountAddresses: ["amal", "bola"],
-    });
-    const postUrl = metadata.extractedTags["fc:frame:post_url"];
-    const response = await framesClient.proxy.post(postUrl, signedPayload);
-    expect(response).toBeDefined();
-    expect(response.extractedTags["fc:frame"]).toEqual("vNext");
+      const metadata = await framesClient.proxy.readMetadata(frameUrl);
+      expect(metadata).toBeDefined();
+      const signedPayload = await framesClient.signFrameAction({
+        frameUrl,
+        buttonIndex: 1,
+        conversationTopic: "foo",
+        participantAccountAddresses: ["amal", "bola"],
+      });
+      const postUrl = metadata.extractedTags["fc:frame:post_url"];
+      const response = await framesClient.proxy.post(postUrl, signedPayload);
+      expect(response).toBeDefined();
+      expect(response.extractedTags["fc:frame"]).toEqual("vNext");
 
-    const imageUrl = response.extractedTags["fc:frame:image"];
-    const mediaUrl = framesClient.proxy.mediaUrl(imageUrl);
+      const imageUrl = response.extractedTags["fc:frame:image"];
+      const mediaUrl = framesClient.proxy.mediaUrl(imageUrl);
 
-    const downloadedMedia = await fetch(mediaUrl);
-    expect(downloadedMedia.ok).toBeTruthy();
-    expect(downloadedMedia.headers.get("content-type")).toEqual("image/png");
-  });
+      const downloadedMedia = await fetch(mediaUrl);
+      expect(downloadedMedia.ok).toBeTruthy();
+      expect(downloadedMedia.headers.get("content-type")).toEqual("image/png");
+    },
+    // Add a long timeout because Vercel cold starts can be slow
+    { timeout: 20000 },
+  );
 });

--- a/packages/frames-client/src/index.test.ts
+++ b/packages/frames-client/src/index.test.ts
@@ -82,12 +82,12 @@ describe("signFrameAction", () => {
       conversationTopic: "foo",
       participantAccountAddresses: ["amal", "bola"],
     });
-    const postUrl = metadata.metaTags["fc:frame:post_url"];
+    const postUrl = metadata.extractedTags["fc:frame:post_url"];
     const response = await framesClient.proxy.post(postUrl, signedPayload);
     expect(response).toBeDefined();
-    expect(response.metaTags["fc:frame"]).toEqual("vNext");
+    expect(response.extractedTags["fc:frame"]).toEqual("vNext");
 
-    const imageUrl = response.metaTags["fc:frame:image"];
+    const imageUrl = response.extractedTags["fc:frame:image"];
     const mediaUrl = framesClient.proxy.mediaUrl(imageUrl);
 
     const downloadedMedia = await fetch(mediaUrl);

--- a/packages/frames-client/src/index.ts
+++ b/packages/frames-client/src/index.ts
@@ -1,19 +1,31 @@
 import type { Client } from "@xmtp/xmtp-js";
-import { frames } from "@xmtp/proto";
+import {
+  signature as signatureProto,
+  publicKey as publicKeyProto,
+  frames,
+} from "@xmtp/proto";
 import { sha256 } from "@noble/hashes/sha256";
 import Long from "long";
 import { PROTOCOL_VERSION } from "./constants";
-import type { FrameActionInputs, FramePostPayload } from "./types";
+import type {
+  FrameActionInputs,
+  FramePostPayload,
+  ReactNativeClient,
+} from "./types";
 import { v1ToV2Bundle } from "./converters";
-import { base64Encode, buildOpaqueIdentifier } from "./utils";
+import {
+  base64Encode,
+  buildOpaqueIdentifier,
+  isReactNativeClient,
+} from "./utils";
 import OpenFramesProxy from "./proxy";
 
 export class FramesClient {
-  xmtpClient: Client;
+  xmtpClient: Client | ReactNativeClient;
 
   proxy: OpenFramesProxy;
 
-  constructor(xmtpClient: Client, proxy?: OpenFramesProxy) {
+  constructor(xmtpClient: Client | ReactNativeClient, proxy?: OpenFramesProxy) {
     this.xmtpClient = xmtpClient;
     this.proxy = proxy || new OpenFramesProxy();
   }
@@ -53,18 +65,40 @@ export class FramesClient {
     const actionBody = frames.FrameActionBody.encode(actionBodyInputs).finish();
 
     const digest = sha256(actionBody);
-    const signature = await this.xmtpClient.keystore.signDigest({
-      digest,
-      identityKey: true,
-      prekeyIndex: undefined,
-    });
+    const signature = await this.signDigest(digest);
 
-    const publicKeyBundle = await this.xmtpClient.keystore.getPublicKeyBundle();
+    const publicKeyBundle = await this.getPublicKeyBundle();
 
     return frames.FrameAction.encode({
       actionBody,
       signature,
       signedPublicKeyBundle: v1ToV2Bundle(publicKeyBundle),
     }).finish();
+  }
+
+  private async signDigest(
+    digest: Uint8Array,
+  ): Promise<signatureProto.Signature> {
+    if (isReactNativeClient(this.xmtpClient)) {
+      const signatureBytes = await this.xmtpClient.sign(digest, {
+        kind: "identity",
+      });
+      return signatureProto.Signature.decode(signatureBytes);
+    }
+
+    return this.xmtpClient.keystore.signDigest({
+      digest,
+      identityKey: true,
+      prekeyIndex: undefined,
+    });
+  }
+
+  private async getPublicKeyBundle(): Promise<publicKeyProto.PublicKeyBundle> {
+    if (isReactNativeClient(this.xmtpClient)) {
+      const bundleBytes = await this.xmtpClient.exportPublicKeyBundle();
+      return publicKeyProto.PublicKeyBundle.decode(bundleBytes);
+    }
+
+    return this.xmtpClient.keystore.getPublicKeyBundle();
   }
 }

--- a/packages/frames-client/src/proxy.ts
+++ b/packages/frames-client/src/proxy.ts
@@ -1,0 +1,79 @@
+import { OPEN_FRAMES_PROXY_URL } from "./constants";
+import { ApiError } from "./errors";
+import type {
+  FramePostPayload,
+  FramesApiRedirectResponse,
+  FramesApiResponse,
+} from "./types";
+
+export default class OpenFramesProxy {
+  baseUrl: string;
+
+  constructor(baseUrl: string = OPEN_FRAMES_PROXY_URL) {
+    this.baseUrl = baseUrl;
+  }
+
+  async readMetadata(url: string): Promise<FramesApiResponse> {
+    const response = await fetch(
+      `${this.baseUrl}?url=${encodeURIComponent(url)}`,
+    );
+
+    if (!response.ok) {
+      throw new ApiError(`Failed to read metadata for ${url}`, response.status);
+    }
+
+    return (await response.json()) as FramesApiResponse;
+  }
+
+  async post(
+    url: string,
+    payload: FramePostPayload,
+  ): Promise<FramesApiResponse> {
+    const response = await fetch(
+      `${this.baseUrl}?url=${encodeURIComponent(url)}`,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to post to frame: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return (await response.json()) as FramesApiResponse;
+  }
+
+  async postRedirect(
+    url: string,
+    payload: FramePostPayload,
+  ): Promise<FramesApiRedirectResponse> {
+    const response = await fetch(
+      `${this.baseUrl}redirect?url=${encodeURIComponent(url)}`,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to post to frame: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return (await response.json()) as FramesApiRedirectResponse;
+  }
+
+  mediaUrl(url: string): string {
+    return `${this.baseUrl}media?url=${encodeURIComponent(url)}`;
+  }
+}

--- a/packages/frames-client/src/types.ts
+++ b/packages/frames-client/src/types.ts
@@ -2,12 +2,18 @@ import type { OpenFramesUntrustedData } from "@open-frames/types";
 
 export type FramesApiResponse = {
   url: string;
-  extractedTags: { [k: string]: string };
+  metaTags: { [k: string]: string };
+};
+
+export type FramesApiRedirectResponse = {
+  originalUrl: string;
+  redirectedTo: string;
 };
 
 export type FramePostUntrustedData = OpenFramesUntrustedData & {
   walletAddress: string; // Untrusted version of the wallet address
   opaqueConversationIdentifier: string; // A hash of the conversation topic and the participants
+  unixTimestamp: number;
 };
 
 export type FramePostTrustedData = {

--- a/packages/frames-client/src/types.ts
+++ b/packages/frames-client/src/types.ts
@@ -2,7 +2,7 @@ import type { OpenFramesUntrustedData } from "@open-frames/types";
 
 export type FramesApiResponse = {
   url: string;
-  metaTags: { [k: string]: string };
+  extractedTags: { [k: string]: string };
 };
 
 export type FramesApiRedirectResponse = {

--- a/packages/frames-client/src/types.ts
+++ b/packages/frames-client/src/types.ts
@@ -42,3 +42,14 @@ export type FrameActionInputs = {
   frameUrl: string;
   buttonIndex: number;
 } & ConversationActionInputs;
+
+type KeyType = {
+  kind: "identity" | "prekey";
+  prekeyIndex?: number | undefined;
+};
+
+export type ReactNativeClient = {
+  address: string;
+  exportPublicKeyBundle(): Promise<Uint8Array>;
+  sign(digest: Uint8Array, type: KeyType): Promise<Uint8Array>;
+};

--- a/packages/frames-client/src/utils.ts
+++ b/packages/frames-client/src/utils.ts
@@ -1,6 +1,7 @@
 import { fetcher } from "@xmtp/proto";
 import { sha256 } from "@noble/hashes/sha256";
-import type { FrameActionInputs } from "./types";
+import type { Client } from "@xmtp/xmtp-js";
+import type { FrameActionInputs, ReactNativeClient } from "./types";
 import { InvalidArgumentsError } from "./errors";
 
 const { b64Encode } = fetcher;
@@ -40,5 +41,16 @@ export function buildOpaqueIdentifier(inputs: FrameActionInputs): string {
         ...participantAccountAddresses.map((p) => p.toLowerCase()).sort(),
       ),
     ),
+  );
+}
+
+export function isReactNativeClient(
+  client: Client | ReactNativeClient,
+): client is ReactNativeClient {
+  const assertedClient = client as ReactNativeClient;
+  return (
+    typeof assertedClient.sign === "function" &&
+    typeof assertedClient.exportPublicKeyBundle === "function" &&
+    !("keystore" in client)
   );
 }


### PR DESCRIPTION
## Summary

- Breaks apart the Frames Proxy functionality from the message signing
- Adds support for getting a proxied image URL, which should be safe to just drop into an `<image>` tag
- Adds support for `post_redirect` frames types

## Upgrade guide

- Replace usage of `FramesClient.readMetadata(...)` with `framesClient.proxy.readMetadata(...)`
- Replace usage of `FramesClient.postToFrame(...)` with `framesClient.proxy.post(...)`