### PR TITLE
Check both the walletEcdsaCompact and the ecdsaCompact

### DIFF
--- a/.changeset/twelve-schools-decide.md
+++ b/.changeset/twelve-schools-decide.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/frames-client": patch
+---
+
+Fix bug with identity key translation

--- a/packages/frames-client/src/converters.ts
+++ b/packages/frames-client/src/converters.ts
@@ -18,7 +18,8 @@ function toSignedPublicKey(
   let v1Signature = v1Key.signature;
   if (signedByWallet) {
     v1Signature = {
-      walletEcdsaCompact: v1Signature.ecdsaCompact,
+      walletEcdsaCompact:
+        v1Signature.walletEcdsaCompact || v1Signature.ecdsaCompact,
       ecdsaCompact: undefined,
     };
   }


### PR DESCRIPTION
## Summary

We seem to be getting different identity key signature formats between iOS and Javascript. This change makes it accomodate both