### PR TITLE
Reorganize dependencies

### DIFF
--- a/.changeset/cool-bananas-invite.md
+++ b/.changeset/cool-bananas-invite.md
@@ -1,0 +1,7 @@
+---
+"@xmtp/react-sdk": major
+---
+
+Reorganize dependencies
+
+**BREAKING CHANGE:** Some `dependencies` have been moved to `peerDependencies` and must now be installed separately. This includes `react`, `@xmtp/xmtp-js`, `@xmtp/content-type-reaction`, `@xmtp/content-type-remote-attachment`, and `@xmtp/content-type-reply`.

--- a/apps/react/package.json
+++ b/apps/react/package.json
@@ -24,6 +24,7 @@
     "@xmtp/content-type-remote-attachment": "^1.1.8",
     "@xmtp/content-type-reply": "^1.1.9",
     "@xmtp/react-sdk": "workspace:*",
+    "@xmtp/xmtp-js": "^11.5.0",
     "date-fns": "^3.4.0",
     "react": "^18.2.0",
     "react-18-blockies": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "typecheck": "FORCE_COLOR=1 turbo run typecheck"
   },
   "resolutions": {
-    "@xmtp/xmtp-js": "^11.4.1",
     "viem": "2.7.15"
   },
   "dependencies": {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -70,17 +70,11 @@
     ]
   },
   "dependencies": {
-    "@xmtp/content-type-reaction": "^1.1.7",
-    "@xmtp/content-type-remote-attachment": "^1.1.8",
-    "@xmtp/content-type-reply": "^1.1.9",
-    "@xmtp/xmtp-js": "^11.5.0",
     "async-mutex": "^0.5.0",
     "date-fns": "^3.4.0",
     "dexie": "^3.2.6",
     "dexie-react-hooks": "^1.1.7",
-    "react": "^18.2.0",
     "uuid": "^9.0.1",
-    "viem": "^2.7.15",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -93,26 +87,34 @@
     "@types/uuid": "^9.0.8",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitest/coverage-v8": "^1.3.1",
+    "@xmtp/content-type-reaction": "^1.1.7",
+    "@xmtp/content-type-remote-attachment": "^1.1.8",
+    "@xmtp/content-type-reply": "^1.1.9",
     "@xmtp/tsconfig": "workspace:*",
+    "@xmtp/xmtp-js": "^11.5.0",
     "eslint": "^8.57.0",
     "eslint-config-xmtp-web": "workspace:*",
     "fake-indexeddb": "^5.0.2",
     "happy-dom": "^13.8.2",
     "prettier": "^3.2.5",
-    "react-dom": "^18.2.0",
+    "react": "^18.2.0",
     "rollup": "^4.13.0",
     "rollup-plugin-dts": "^6.1.0",
     "rollup-plugin-filesize": "^10.0.0",
     "rollup-plugin-tsconfig-paths": "^1.5.2",
     "typedoc": "^0.25.12",
     "typescript": "^5.4.2",
+    "viem": "^2.7.15",
     "vite": "^5.1.6",
     "vite-tsconfig-paths": "^4.3.1",
     "vitest": "^1.3.1"
   },
   "peerDependencies": {
-    "@xmtp/xmtp-js": "^11.4.1",
-    "react": ">=16.14"
+    "@xmtp/content-type-reaction": "^1.1.7",
+    "@xmtp/content-type-remote-attachment": "^1.1.8",
+    "@xmtp/content-type-reply": "^1.1.9",
+    "@xmtp/xmtp-js": "^11.5.0",
+    "react": "^16.14.0 || ^17 || ^18"
   },
   "engines": {
     "node": ">=18"

--- a/packages/react-sdk/src/hooks/useClient.ts
+++ b/packages/react-sdk/src/hooks/useClient.ts
@@ -1,7 +1,6 @@
 import { useCallback, useContext, useRef, useState } from "react";
-import type { ClientOptions, Signer } from "@xmtp/xmtp-js";
+import type { ClientOptions } from "@xmtp/xmtp-js";
 import { Client } from "@xmtp/xmtp-js";
-import type { WalletClient } from "viem";
 import { XMTPContext } from "../contexts/XMTPContext";
 import type { OnError } from "@/sharedTypes";
 import { processUnprocessedMessages } from "@/helpers/caching/messages";
@@ -21,7 +20,7 @@ export type InitializeClientOptions = {
   /**
    * The signer (wallet) to associate with the XMTP client
    */
-  signer?: Signer | WalletClient | null;
+  signer?: Parameters<typeof Client.create>[0];
 };
 
 /**

--- a/packages/react-sdk/src/hooks/useStreamConsentList.ts
+++ b/packages/react-sdk/src/hooks/useStreamConsentList.ts
@@ -67,11 +67,11 @@ export const useStreamConsentList = (
 
         for await (const action of await stream) {
           // update the local DB, but don't publish to the network
-          if (action.allow) {
-            void allow(action.allow.walletAddresses, true);
+          if (action.allowAddress) {
+            void allow(action.allowAddress.walletAddresses, true);
           }
-          if (action.block) {
-            void deny(action.block.walletAddresses, true);
+          if (action.denyAddress) {
+            void deny(action.denyAddress.walletAddresses, true);
           }
           void onAction?.(action);
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5508,6 +5508,7 @@ __metadata:
     "@xmtp/content-type-reply": "npm:^1.1.9"
     "@xmtp/react-sdk": "workspace:*"
     "@xmtp/tsconfig": "workspace:*"
+    "@xmtp/xmtp-js": "npm:^11.5.0"
     date-fns: "npm:^3.4.0"
     eslint: "npm:^8.57.0"
     eslint-config-xmtp-web: "workspace:*"
@@ -5549,7 +5550,6 @@ __metadata:
     happy-dom: "npm:^13.8.2"
     prettier: "npm:^3.2.5"
     react: "npm:^18.2.0"
-    react-dom: "npm:^18.2.0"
     rollup: "npm:^4.13.0"
     rollup-plugin-dts: "npm:^6.1.0"
     rollup-plugin-filesize: "npm:^10.0.0"
@@ -5563,8 +5563,11 @@ __metadata:
     vitest: "npm:^1.3.1"
     zod: "npm:^3.22.4"
   peerDependencies:
-    "@xmtp/xmtp-js": ^11.4.1
-    react: ">=16.14"
+    "@xmtp/content-type-reaction": ^1.1.7
+    "@xmtp/content-type-remote-attachment": ^1.1.8
+    "@xmtp/content-type-reply": ^1.1.9
+    "@xmtp/xmtp-js": ^11.5.0
+    react: ^16.14.0 || ^17 || ^18
   languageName: unknown
   linkType: soft
 
@@ -5643,6 +5646,21 @@ __metadata:
   version: 0.3.6
   resolution: "@xmtp/user-preferences-bindings-wasm@npm:0.3.6"
   checksum: 10/a7475945996142e9238b74f66ae4d8c4d04dfe758da9510933823499f52b519b53b1e5b8e807c69426e2ec73ccec20b1f388ed16e74606645cd5dc0ff28247f3
+  languageName: node
+  linkType: hard
+
+"@xmtp/xmtp-js@npm:^11.3.12, @xmtp/xmtp-js@npm:^11.5.0":
+  version: 11.5.0
+  resolution: "@xmtp/xmtp-js@npm:11.5.0"
+  dependencies:
+    "@noble/secp256k1": "npm:1.7.1"
+    "@xmtp/proto": "npm:3.45.0"
+    "@xmtp/user-preferences-bindings-wasm": "npm:^0.3.6"
+    async-mutex: "npm:^0.5.0"
+    elliptic: "npm:^6.5.4"
+    long: "npm:^5.2.3"
+    viem: "npm:2.7.15"
+  checksum: 10/767eab8fff15d3d7fdcecba7a08fad8650b8f2392c797a09429739a6730ca1daacdcbe2056bccb6a6e19a2f90b9adc73f0f199c5a9b7b348a29e9a9110db5108
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This PR aims to fix issues related to having the wrong and/or multiple versions of XMTP dependencies when using the React SDK. Since these changes require integrators to add certain XMTP dependencies to their `package.json`, it's being marked as a breaking change.

### React SDK

* Moved `@xmtp/*` dependencies to `peerDependencies` and `devDependencies`
* Moved `viem` to `devDependencies`
* Moved `react` to `devDependencies`
* Removed `react-dom`
* Updated `useStreamConsentList` hook to use latest `@xmtp/proto` naming

### React app

* Added `@xmtp/xmtp-js` dependency

### Misc

* Removed `@xmtp/xmtp-js` resolution at repo root