### PR TITLE
Export `useMessage` hook

### DIFF
--- a/packages/react-sdk/src/hooks/useMessage.ts
+++ b/packages/react-sdk/src/hooks/useMessage.ts
@@ -28,8 +28,8 @@ export type SendMessageOptions = Omit<SendOptions, "contentType"> &
   Pick<UseSendMessageOptions, "onSuccess" | "onError">;
 
 /**
- * This hook is for internal use only and wraps helper functions to include
- * the client, DB instance, and other values for easier consumption.
+ * This hook wraps helper functions to include the client, DB instance, and
+ * other values for easier consumption.
  */
 export const useMessage = () => {
   const xmtpContext = useContext(XMTPContext);

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -34,6 +34,7 @@ export {
 // messages
 export { useLastMessage } from "./hooks/useLastMessage";
 export { useCanMessage } from "./hooks/useCanMessage";
+export { useMessage } from "./hooks/useMessage";
 export { useMessages } from "./hooks/useMessages";
 export { useSendMessage } from "./hooks/useSendMessage";
 export { useResendMessage } from "./hooks/useResendMessage";


### PR DESCRIPTION
# Summary

* Exported `useMessage` hook
* Updated `useMessage` since it's no longer "internal use only"