### PR TITLE
Add CommonJS export to consent-proof-signature

### DIFF
--- a/.changeset/big-yaks-thank.md
+++ b/.changeset/big-yaks-thank.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/consent-proof-signature": patch
+---
+
+Add CommonJS export to `consent-proof-signature` package

--- a/packages/consent-proof-signature/package.json
+++ b/packages/consent-proof-signature/package.json
@@ -27,10 +27,11 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "default": "./lib/index.js"
+      "require": "./lib/index.cjs",
+      "import": "./lib/index.js"
     }
   },
-  "main": "index.js",
+  "main": "lib/index.cjs",
   "module": "lib/index.js",
   "browser": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -81,11 +82,9 @@
     "rollup": "^4.13.0",
     "rollup-plugin-dts": "^6.1.0",
     "rollup-plugin-filesize": "^10.0.0",
-    "rollup-plugin-tsconfig-paths": "^1.5.2",
     "typedoc": "^0.25.12",
     "typescript": "^5.4.2",
     "vite": "^5.1.6",
-    "vite-tsconfig-paths": "^4.3.1",
     "vitest": "^1.3.1"
   },
   "packageManager": "yarn@4.0.2",

--- a/packages/consent-proof-signature/rollup.config.js
+++ b/packages/consent-proof-signature/rollup.config.js
@@ -1,12 +1,10 @@
 import { defineConfig } from "rollup";
 import typescript from "@rollup/plugin-typescript";
 import { dts } from "rollup-plugin-dts";
-import tsConfigPaths from "rollup-plugin-tsconfig-paths";
 import terser from "@rollup/plugin-terser";
 import filesize from "rollup-plugin-filesize";
 
 const plugins = [
-  tsConfigPaths(),
   typescript({
     declaration: false,
     declarationMap: false,
@@ -16,7 +14,7 @@ const plugins = [
   }),
 ];
 
-const external = ["@xmtp/proto", "node:crypto"];
+const external = ["@xmtp/proto", "node:crypto", "long"];
 
 export default defineConfig([
   {
@@ -24,6 +22,16 @@ export default defineConfig([
     output: {
       file: "lib/index.js",
       format: "es",
+      sourcemap: true,
+    },
+    external,
+    plugins,
+  },
+  {
+    input: "src/index.ts",
+    output: {
+      file: "lib/index.cjs",
+      format: "cjs",
       sourcemap: true,
     },
     external,
@@ -45,6 +53,6 @@ export default defineConfig([
       file: "lib/index.d.ts",
       format: "es",
     },
-    plugins: [tsConfigPaths(), dts()],
+    plugins: [dts()],
   },
 ]);

--- a/packages/consent-proof-signature/vitest.config.ts
+++ b/packages/consent-proof-signature/vitest.config.ts
@@ -1,11 +1,8 @@
 import { defineConfig, mergeConfig } from "vite";
 import { defineConfig as defineVitestConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vitejs.dev/config/
-const viteConfig = defineConfig({
-  plugins: [tsconfigPaths()],
-});
+const viteConfig = defineConfig({});
 
 const vitestConfig = defineVitestConfig({
   test: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5384,11 +5384,9 @@ __metadata:
     rollup: "npm:^4.13.0"
     rollup-plugin-dts: "npm:^6.1.0"
     rollup-plugin-filesize: "npm:^10.0.0"
-    rollup-plugin-tsconfig-paths: "npm:^1.5.2"
     typedoc: "npm:^0.25.12"
     typescript: "npm:^5.4.2"
     vite: "npm:^5.1.6"
-    vite-tsconfig-paths: "npm:^4.3.1"
     vitest: "npm:^1.3.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
# Summary

* Added CommonJS export for the `consent-proof-signature` package
* Updated `package.json` exports for the CommonJS export
* Removed unused `rollup-plugin-tsconfig-paths` and `vite-tsconfig-paths` dependencies
* Updated `externals` config to include `long`