### PR TITLE
Transaction Id Fix

### DIFF
--- a/.changeset/dull-toys-fold.md
+++ b/.changeset/dull-toys-fold.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/frames-client": patch
+---
+
+fix for transaction id

--- a/packages/frames-client/package.json
+++ b/packages/frames-client/package.json
@@ -71,7 +71,7 @@
     "long": "^5.2.3"
   },
   "devDependencies": {
-    "@open-frames/types": "^0.1.0",
+    "@open-frames/types": "^0.1.1",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
     "@xmtp/tsconfig": "workspace:*",

--- a/packages/frames-client/src/client.ts
+++ b/packages/frames-client/src/client.ts
@@ -63,6 +63,7 @@ export class FramesClient {
         state,
         // The address associated with initiating a transaction
         address,
+        transactionId,
       },
       trustedData: {
         messageBytes: base64Encode(signedAction),

--- a/packages/frames-client/src/index.test.ts
+++ b/packages/frames-client/src/index.test.ts
@@ -25,6 +25,7 @@ describe("signFrameAction", () => {
       participantAccountAddresses: ["amal", "bola"],
       state: "state",
       address: "0x...",
+      transactionId: "123",
     });
 
     // Below addresses are typically the same but can technically be different
@@ -33,6 +34,8 @@ describe("signFrameAction", () => {
 
     // address references the address associated with initiating a transaction
     expect(signedPayload.untrustedData.address).toEqual("0x...");
+    expect(signedPayload.untrustedData.transactionId).toEqual("123");
+
     expect(signedPayload.untrustedData.url).toEqual(frameUrl);
     expect(signedPayload.untrustedData.buttonIndex).toEqual(buttonIndex);
     expect(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2943,10 +2943,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@open-frames/types@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@open-frames/types@npm:0.1.0"
-  checksum: 10/64a947c0834c9c73e29c7d6ec151a9c3e005baeec034e47ecbca450ec218c598ed7be32ff85087cd7f8403e202e37c9e83d9b4f6a0d4b7e2a562b2cfb30608c3
+"@open-frames/types@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@open-frames/types@npm:0.1.1"
+  checksum: 10/2e23b984123f760e4fd4f205fb50e89725679563f8830a86d9d0c436315b6df02d336a4ab06c583b31c568103bc2a82dbe23d36356909a80fc9a1c0026cc04ee
   languageName: node
   linkType: hard
 
@@ -5433,7 +5433,7 @@ __metadata:
   dependencies:
     "@noble/hashes": "npm:^1.3.3"
     "@open-frames/proxy-client": "npm:^0.3.2"
-    "@open-frames/types": "npm:^0.1.0"
+    "@open-frames/types": "npm:^0.1.1"
     "@rollup/plugin-terser": "npm:^0.4.4"
     "@rollup/plugin-typescript": "npm:^11.1.6"
     "@xmtp/proto": "npm:3.61.1"


### PR DESCRIPTION
Fix to return transactionId from the `signFrameAction` payload.