### PR TITLE
Typo Update index.js

### DIFF
--- a/packages/eslint-config-xmtp-web/index.js
+++ b/packages/eslint-config-xmtp-web/index.js
@@ -47,7 +47,6 @@ module.exports = {
       },
     ],
     "import/prefer-default-export": "off",
-    "import/extensions": "off",
     "react/no-array-index-key": "warn",
     "react/require-default-props": "off",
     "react/prop-types": "off",


### PR DESCRIPTION
**Description**:

There was a duplication of the `import/extensions` rule in the ESLint configuration file. The rule was defined twice in the `rules` section:

```js
"import/extensions": "off",
```

To resolve this issue, I removed one of the duplicate lines, ensuring that the rule is only specified once. This change helps maintain a cleaner configuration and avoid unnecessary repetition.

**Importance**: 
Removing the duplicate rule improves the clarity and maintainability of the ESLint configuration file, ensuring that the linting process runs without redundancy.