### PR TITLE
Fix grammatical error Update README.md

### DIFF
--- a/apps/react/README.md
+++ b/apps/react/README.md
@@ -21,7 +21,7 @@ This React app isn't a complete solution. For example, the list of conversations
 ## Useful commands
 
 - `yarn clean`: Removes `node_modules` and `.turbo` folders
-- `yarn format`: Runs prettier format and write changes
+- `yarn format`: Runs prettier format and writes changes
 - `yarn format:check`: Runs prettier format check
 - `yarn lint`: Runs ESLint
 - `yarn typecheck`: Runs `tsc`


### PR DESCRIPTION
There was a small grammatical error in the "Useful commands" section of the documentation.

- **Incorrect phrase**: "Runs prettier format and write changes"
- **Corrected phrase**: "Runs prettier format and **writes** changes"

This change is important for proper sentence structure and readability, ensuring the instructions are clear and professional.